### PR TITLE
Fix iOS Safari extension bug

### DIFF
--- a/Tools for Autodarts/Shared (App)/ViewController.swift
+++ b/Tools for Autodarts/Shared (App)/ViewController.swift
@@ -1,10 +1,3 @@
-//
-//  ViewController.swift
-//  Shared (App)
-//
-//  Created by Tobias Thiele on 21.03.24.
-//
-
 import WebKit
 
 #if os(iOS)
@@ -29,6 +22,7 @@ class ViewController: PlatformViewController, WKNavigationDelegate, WKScriptMess
 
 #if os(iOS)
         self.webView.scrollView.isScrollEnabled = false
+        self.webView.configuration.mediaTypesRequiringUserActionForPlayback = []
 #endif
 
         self.webView.configuration.userContentController.add(self, name: "controller")

--- a/entrypoints/content/index.ts
+++ b/entrypoints/content/index.ts
@@ -16,6 +16,9 @@ export default defineContentScript({
     } else {
       if (isiOS()) {
         document.querySelector("body")!.style!.minHeight = "calc(100vh + 1px)";
+        await AutodartsToolsSoundAutoplayStatus.setValue(true);
+      } else {
+        await AutodartsToolsSoundAutoplayStatus.setValue(false);
       }
       await waitForElement("#root > div:nth-of-type(1)", 15000);
 
@@ -35,7 +38,6 @@ export default defineContentScript({
         }
       }, 2000);
 
-      await AutodartsToolsSoundAutoplayStatus.setValue(false);
       await waitForElement("#root > div > div:nth-of-type(2)", 15000);
       const ui = await createShadowRootUi(ctx, {
         name: "autodarts-tools-wxt",

--- a/entrypoints/match.content/sounds.ts
+++ b/entrypoints/match.content/sounds.ts
@@ -3,7 +3,7 @@ import { AutodartsToolsCallerConfig } from "@/utils/callerStorage";
 import { AutodartsToolsSoundsConfig } from "@/utils/soundsStorage";
 
 import { playPointsSound, playSound } from "@/utils/playSound";
-import { isCricket, isValidGameMode } from "@/utils/helpers";
+import { isCricket, isValidGameMode, isiOS } from "@/utils/helpers";
 
 export async function sounds() {
   const isCallerEnabled = (await AutodartsToolsConfig.getValue()).caller.enabled && isValidGameMode();
@@ -119,4 +119,18 @@ export async function sounds() {
       }
     }
   }, isBot ? 500 : 0);
+}
+
+export async function playSound(configKey: string, slot: number = 1, arrIndex?: number) {
+  let soundConfig = (await AutodartsToolsSoundsConfig.getValue())[configKey];
+  if (typeof arrIndex === "number") soundConfig = soundConfig[arrIndex];
+  const isSoundsEnabled = (await AutodartsToolsConfig.getValue()).sounds.enabled;
+  const fileName = soundConfig.info;
+  if (!isSoundsEnabled || !fileName) return;
+  const fileData = soundConfig.data;
+  const audio = new Audio(fileData || fileName);
+  if (isiOS()) {
+    audio.autoplay = true;
+  }
+  audio.play();
 }

--- a/entrypoints/match.content/soundsStart.ts
+++ b/entrypoints/match.content/soundsStart.ts
@@ -1,6 +1,7 @@
 import { AutodartsToolsConfig } from "@/utils/storage";
 import { AutodartsToolsSoundsConfig } from "@/utils/soundsStorage";
 import { playSound } from "@/utils/playSound";
+import { isiOS } from "@/utils/helpers";
 
 export async function soundsStart() {
   const config = await AutodartsToolsConfig.getValue();
@@ -8,6 +9,10 @@ export async function soundsStart() {
   if (!config.sounds.enabled) return;
 
   if (soundConfig.gameOn?.data || soundConfig.gameOn?.info) {
+    const audio = new Audio(soundConfig.gameOn.data || soundConfig.gameOn.info);
+    if (isiOS()) {
+      audio.autoplay = true;
+    }
     await playSound("gameOn", 2);
   }
 }

--- a/entrypoints/match.content/soundsWinner.ts
+++ b/entrypoints/match.content/soundsWinner.ts
@@ -3,6 +3,7 @@ import { AutodartsToolsCallerConfig } from "@/utils/callerStorage";
 import { AutodartsToolsSoundsConfig } from "@/utils/soundsStorage";
 import { playPointsSound, playSound } from "@/utils/playSound";
 import { getWinnerPlayerCard } from "@/utils/getElements";
+import { isiOS } from "@/utils/helpers";
 
 export async function soundsWinner() {
   try {
@@ -27,7 +28,11 @@ export async function soundsWinner() {
         setTimeout(() => {
           const winnerSoundIndex = soundsConfig.winner.findIndex(winner => winner.name.toLowerCase() === winnerPlayerName?.toLowerCase());
           const soundIndex = winnerSoundIndex && soundsConfig.winner[winnerSoundIndex]?.info ? winnerSoundIndex : 0;
-          playSound("winner", 2, soundIndex);
+          const audio = new Audio(soundsConfig.winner[soundIndex].data || soundsConfig.winner[soundIndex].info);
+          if (isiOS()) {
+            audio.autoplay = true;
+          }
+          audio.play();
         }, 1000);
       }
     };


### PR DESCRIPTION
Fix audio playback issues in iOS Safari extension.

* Add a check for iOS in `entrypoints/content/index.ts` to ensure audio autoplay is enabled.
* Modify `entrypoints/match.content/sounds.ts` to handle iOS-specific audio playback issues and add a check for iOS in the `playSound` function.
* Update `entrypoints/match.content/soundsStart.ts` to handle iOS-specific audio playback issues.
* Update `entrypoints/match.content/soundsWinner.ts` to handle iOS-specific audio playback issues.
* Update `Tools for Autodarts/Shared (App)/ViewController.swift` to handle iOS-specific audio settings.

