### PR TITLE
Support all game modes for nextPlayerOnTakeOutStuck

### DIFF
--- a/entrypoints/match.content/index.ts
+++ b/entrypoints/match.content/index.ts
@@ -19,7 +19,7 @@ import StreamingMode from "@/entrypoints/match.content/StreamingMode.vue";
 import { sounds } from "@/entrypoints/match.content/sounds";
 import { getBoardStatusEl, getMenu } from "@/utils/getElements";
 import { BoardStatus } from "@/utils/types";
-import { isBullOff, isCricket, isValidGameMode, isX01 } from "@/utils/helpers";
+import { isBullOff, isCricket, isValidGameMode, isX01, isBermuda, isShanghai, isGotcha, isAroundTheClock, isRoundTheWorld, isRandomCheckout, isCountUp, isSegmentTraining } from "@/utils/helpers";
 import { soundsWinner } from "@/entrypoints/match.content/soundsWinner";
 import { setCricketClosedPoints } from "@/entrypoints/match.content/setCricketPoints";
 import { hideMenu } from "@/entrypoints/match.content/hideMenu";

--- a/utils/helpers.ts
+++ b/utils/helpers.ts
@@ -1,8 +1,16 @@
 export const isX01 = () => document.getElementById("ad-ext-game-variant")?.textContent === "X01";
 export const isBullOff = () => document.getElementById("ad-ext-game-variant")?.textContent === "Bull-off";
 export const isCricket = () => document.getElementById("ad-ext-game-variant")?.textContent?.split(" ")[0] === "Cricket";
+export const isBermuda = () => document.getElementById("ad-ext-game-variant")?.textContent === "Bermuda";
+export const isShanghai = () => document.getElementById("ad-ext-game-variant")?.textContent === "Shanghai";
+export const isGotcha = () => document.getElementById("ad-ext-game-variant")?.textContent === "Gotcha";
+export const isAroundTheClock = () => document.getElementById("ad-ext-game-variant")?.textContent === "ATC";
+export const isRoundTheWorld = () => document.getElementById("ad-ext-game-variant")?.textContent === "Round the World";
+export const isRandomCheckout = () => document.getElementById("ad-ext-game-variant")?.textContent === "Random Checkout";
+export const isCountUp = () => document.getElementById("ad-ext-game-variant")?.textContent === "Count Up";
+export const isSegmentTraining = () => document.getElementById("ad-ext-game-variant")?.textContent === "Segment Training";
 
-export const isValidGameMode = () => isX01() || isCricket();
+export const isValidGameMode = () => isX01() || isCricket() || isBermuda() || isShanghai() || isGotcha() || isAroundTheClock() || isRoundTheWorld() || isRandomCheckout() || isCountUp() || isSegmentTraining();
 
 export const soundEffect1 = new Audio();
 export const soundEffect2 = new Audio();


### PR DESCRIPTION
Add support for all game modes in `nextPlayerOnTakeOutStuck`.

* Add functions `isBermuda`, `isShanghai`, `isGotcha`, `isAroundTheClock`, `isRoundTheWorld`, `isRandomCheckout`, `isCountUp`, and `isSegmentTraining` in `utils/helpers.ts` to check for respective game modes.
* Update `isValidGameMode` function in `utils/helpers.ts` to include checks for all game modes.
* Update import statement in `entrypoints/match.content/index.ts` to include the new game mode functions from `utils/helpers.ts`.

