### PR TITLE
Add AVG toggle in Stream-Mode

### DIFF
--- a/components/PageConfig.vue
+++ b/components/PageConfig.vue
@@ -288,6 +288,10 @@
                 <AppToggle v-model="config.streamingMode.boardImage" text-on="LIVE" text-off="IMG" />
                 <p>Toggles the Board between Live and Image mode</p>
               </div>
+              <div v-if="config.streamingMode.enabled" class="grid grid-cols-[5rem_auto] items-center gap-4">
+                <AppToggle v-model="config.streamingMode.avg" />
+                <p>Display AVG</p>
+              </div>
               <input
                 v-model="config.streamingMode.footerText"
                 placeholder="Bottom text of the streaming overlay"

--- a/entrypoints/content/App.vue
+++ b/entrypoints/content/App.vue
@@ -7,7 +7,7 @@
 <script setup lang="ts">
 import PageConfig from "@/components/PageConfig.vue";
 import { waitForElement } from "@/utils";
-import { AutodartsToolsUrlStatus } from "@/utils/storage";
+import { AutodartsToolsUrlStatus, AutodartsToolsConfig, defaultConfig } from "@/utils/storage";
 
 const menuIcon = "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"16\" height=\"16\" viewBox=\"0 0 24 24\"><path fill=\"currentColor\" d=\"M8.8 21H5q-.825 0-1.412-.587T3 19v-3.8q1.2 0 2.1-.762T6 12.5q0-1.175-.9-1.937T3 9.8V6q0-.825.588-1.412T5 4h4q0-1.05.725-1.775T11.5 1.5q1.05 0 1.775.725T14 4h4q.825 0 1.413.588T20 6v4q1.05 0 1.775.725T22.5 12.5q0 1.05-.725 1.775T20 15v4q0 .825-.587 1.413T18 21h-3.8q0-1.25-.787-2.125T11.5 18q-1.125 0-1.912.875T8.8 21\"/></svg>";
 
@@ -76,6 +76,12 @@ onMounted(async () => {
 
   const collapseButton = document.querySelector("button[aria-label='Collapse side bar']") as HTMLButtonElement | null;
   if (collapseButton) collapseButton.addEventListener("click", initMenu);
+
+  const config = await AutodartsToolsConfig.getValue();
+  await AutodartsToolsConfig.setValue({
+    ...JSON.parse(JSON.stringify(defaultConfig)),
+    ...JSON.parse(JSON.stringify(config)),
+  });
 });
 
 onBeforeUnmount(() => {

--- a/entrypoints/match.content/StreamingMode.vue
+++ b/entrypoints/match.content/StreamingMode.vue
@@ -249,17 +249,21 @@ const game = reactive<{
   footer: string;
   throws: string[];
   turnPoints?: string;
+  avg?: string;
 }>({
   title: "",
   players: [],
   footer: "Game provided by Autodarts.io",
   throws: [],
+  avg: "",
 });
 
 const config: Ref<IConfig | null> = ref(null);
 const coords = ref("");
 
 const streamingModeButton: Ref<HTMLAnchorElement | null> = ref(null);
+
+const showAvg = computed(() => config.value?.streamingMode.avg);
 
 onMounted(async () => {
   config.value = await AutodartsToolsConfig.getValue();
@@ -344,6 +348,12 @@ async function setGameData(matchStatus: IMatchStatus) {
       } catch (e) {
         console.error(e);
       }
+    }
+
+    if (config.value.streamingMode.avg) {
+      const totalPoints = matchStatus.playerInfo.reduce((acc, player) => acc + parseInt(player.score), 0);
+      const totalDarts = matchStatus.playerInfo.reduce((acc, player) => acc + parseInt(player.darts || "0"), 0);
+      game.avg = (totalPoints / totalDarts).toFixed(2);
     }
   } catch (e) {
     console.error(e);

--- a/utils/storage.ts
+++ b/utils/storage.ts
@@ -20,6 +20,7 @@ export interface IConfig {
     footerText: string;
     board: boolean;
     boardImage: boolean;
+    avg: boolean; // P4394
     scoreBoardSettings: {
       scale: number;
       x: number;
@@ -157,6 +158,7 @@ export const defaultConfig: IConfig = {
     footerText: "",
     board: false,
     boardImage: false,
+    avg: false, // P42de
     scoreBoardSettings: {
       scale: 1,
       x: 0,


### PR DESCRIPTION
Add a toggle option for AVG in Stream-Mode.

* **components/PageConfig.vue**
  - Add a new `AppToggle` component for toggling AVG in Stream-Mode.
  - Bind the new toggle to `config.streamingMode.avg`.
  - Update the `config` object to include `avg` in `streamingMode`.

* **entrypoints/match.content/StreamingMode.vue**
  - Add a computed property to check if AVG should be displayed.
  - Conditionally render the AVG element based on the new computed property.
  - Update the `setGameData` method to include AVG calculation.

* **utils/storage.ts**
  - Add a new field `avg` to the `streamingMode` object in the `IConfig` interface.
  - Update the `defaultConfig` to include the new `avg` field in `streamingMode`.

* **entrypoints/content/App.vue**
  - Initialize the new `avg` field in the `config` object.

