### PR TITLE
Zoom: align at the bottom right of the window

### DIFF
--- a/entrypoints/match.content/Zoom.vue
+++ b/entrypoints/match.content/Zoom.vue
@@ -8,7 +8,7 @@
   <div
     v-if="boardImages.length > 0 && throws > 0 && position !== 'center' && shouldShowZoom"
     :class="twMerge(
-      'pointer-events-none fixed bottom-4 mx-auto flex max-w-[1366px] justify-end',
+      'pointer-events-none fixed bottom-4 mx-auto flex justify-end',
       position === 'bottom-right' ? 'right-4' : 'left-4',
     )"
     :style="{
@@ -252,7 +252,7 @@ function resetZoomDivs() {
 }
 
 onMounted(async () => {
-  console.log("Autodarts Tools: Animations mounted");
+  console.log("Autodarts Tools: Zoom mounted");
 
   config.value = await AutodartsToolsConfig.getValue();
   if (config.value.zoom.position === "center") initCenterZoom();


### PR DESCRIPTION
Actually the zoomed images overlaps the board when "bottom-right" position is selected because they are aligned with the player scores.
![image](https://github.com/user-attachments/assets/91e36d46-1048-4097-9499-541cd659b1b6)

This change moves the zoomed images to the bottom right of the window, that's the same behavior as when "bottom-left" position is selected.
![image](https://github.com/user-attachments/assets/e23e570c-42e9-4e1e-9331-25cc9b176196)
