### PR TITLE
feat: Add `opponent_turn` trigger logic for WLED

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,6 +379,7 @@ Effects can be triggered by various game events using these triggers:
 - **`bot_throw`**: Triggered when a CPU/bot player throws
 - **`gameshot_[player name]`**: player specific gameshot trigger
 - **`matchshot_[player name]`**: player specific matchshot trigger
+- **`opponent_turn`**: At the start of each non-present opponent's turn. This trigger affects Bots and Players on remote boards. This is triggered instead of the generic `gameon` effect.
 
 ##### Board-Specific Effects
 - **Board IDs**: Configure specific board IDs to limit effects to certain boards

--- a/components/Settings/Wled.vue
+++ b/components/Settings/Wled.vue
@@ -62,13 +62,20 @@
               </div>
             </div>
 
-            <div>
+            <div class="flex flex-col gap-20 sm:flex-row">
               <div class="mt-2 flex items-center gap-2">
                 <div class="flex items-center gap-2">
                   <span>trigger Effects only once</span>
                 </div>
                 <AppToggle @update:model-value="config.wledFx.onlyOnce = !config.wledFx.onlyOnce"
                   v-model="config.wledFx.onlyOnce" />
+              </div>
+              <div class="mt-2 flex items-center gap-2">
+                <div class="flex items-center gap-2">
+                  <span>trigger `opponent_turn` Effects</span>
+                </div>
+                <AppToggle @update:model-value="config.wledFx.opponentTurnEffectEnabled = !config.wledFx.opponentTurnEffectEnabled"
+                  v-model="config.wledFx.opponentTurnEffectEnabled" />
               </div>
             </div>
 

--- a/entrypoints/match.content/wled.ts
+++ b/entrypoints/match.content/wled.ts
@@ -200,8 +200,9 @@ async function processGameData(
   currentBoardId = currentPlayer?.boardId;
 
   const isOpponentTurn = isBot || (config.wledFx.boardIds.length > 0 && !config.wledFx.boardIds.includes(currentBoardId));
+  const opponentTurnEffectEnabled = config.wledFx.opponentTurnEffectEnabled;
 
-  if (isOpponentTurn && isTriggerPresent("opponent_turn")) {
+  if (opponentTurnEffectEnabled && isOpponentTurn && isTriggerPresent("opponent_turn")) {
     nextEffect = "opponent_turn";
   }
 

--- a/entrypoints/match.content/wled.ts
+++ b/entrypoints/match.content/wled.ts
@@ -194,12 +194,19 @@ async function processGameData(
   // gameon is the default effect to play when no other event happened
   let nextEffect: string | IWled = "gameon";
 
+  const currentPlayer = gameData.match.players?.[gameData.match.player];
+  const isBot = currentPlayer?.cpuPPR !== null;
+  const playerName = currentPlayer?.name;
+  currentBoardId = currentPlayer?.boardId;
+
+  const isOpponentTurn = isBot || (config.wledFx.boardIds.length > 0 && !config.wledFx.boardIds.includes(currentBoardId));
+
+  if (isOpponentTurn && isTriggerPresent("opponent_turn")) {
+    nextEffect = "opponent_turn";
+  }
+
   // Play player effect when it's the next players turn
   if (gameData.match.turns[0].throws.length === 0) {
-    const currentPlayer = gameData.match.players?.[gameData.match.player];
-    const isBot = currentPlayer?.cpuPPR !== null;
-    const playerName = currentPlayer?.name;
-
     if (isBot) {
       console.log("Autodarts Tools: WLED: Bot player detected");
       nextEffect = "bot_throw";
@@ -231,8 +238,6 @@ async function processGameData(
     // found effect for match variant
     nextEffect = effect;
   }
-
-  currentBoardId = gameData.match.players?.[gameData.match.player].boardId;
 
   if (
     config.wledFx.boardIds.length > 0

--- a/utils/storage.ts
+++ b/utils/storage.ts
@@ -152,6 +152,7 @@ export interface IConfig {
   wledFx: {
     enabled: boolean;
     onlyOnce: boolean;
+    opponentTurnEffectEnabled: boolean;
     boardIds: string[];
     effects: IWled[];
   };
@@ -681,6 +682,7 @@ export const defaultConfig: IConfig = {
   wledFx: {
     enabled: false,
     onlyOnce: true,
+    opponentTurnEffectEnabled: false,
     boardIds: [],
     effects: [
       {


### PR DESCRIPTION
### Problem

When using WLED, it’s easy to see the `gameon` effect when not watching the screen. As a result, players regularly start throwing their darts while it is a bot or remote player’s turn, which usually requires manual intervention to resolve.

### Solution

Added an `opponent_turn` trigger to WLED events. This allows an alternative effect to run while bot or remote player turns are in progress.

### Changes

- Added an `opponent_turn` trigger for WLED.
- Added an `opponent_turn` WLED setting, defaulting to **false**, to prevent regressions for existing users. This trigger would otherwise override the `gameon` trigger.
- Updated README.md with documentation for the new trigger.