### PR TITLE
Add caller option: Prefer combined throws (suppress duplicate points sound)

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ The Caller feature provides voice announcements during your darts gameplay, simi
 #### Configuration Options
 - **Call Every Dart**: Announces each dart as it's thrown, rather than waiting for the end of a turn
 - **Call Checkout**: Announces possible checkout combinations when a player is on a checkout score
+- **Prefer Combined Throws**: When enabled and a sound for the exact dart combination (e.g. `s20_s5_s1`) exists, the generic points sound (e.g. `26`) is skipped for that throw
 - **Custom Sound Library**: Add, edit, and organize voice clips for different game events
 - **Text-to-Speech (TTS) Generation**: Generate caller sounds directly from text using the built-in "Generate TTS" button — no external files needed. Select from any voice installed on your device, adjust speed and pitch, and preview before saving. Your last-used voice, speed, and pitch settings are remembered across sessions.
 - **Bulk Upload with Trigger Assignment**: When uploading multiple files, you can assign the same trigger to all files at once, making it easy to set up larger sound sets without manually assigning triggers to each file individually

--- a/components/Settings/Caller.vue
+++ b/components/Settings/Caller.vue
@@ -55,6 +55,16 @@
                   v-model="config.caller.callCheckout"
                 />
               </div>
+
+              <div class="mt-2 flex items-center gap-2">
+                <div class="flex items-center gap-2">
+                  <span>Prefer combined throws</span>
+                </div>
+                <AppToggle
+                  @update:model-value="config.caller.preferCombinedThrows = !config.caller.preferCombinedThrows"
+                  v-model="config.caller.preferCombinedThrows"
+                />
+              </div>
             </div>
 
             <div class="mt-2 flex items-center gap-2 text-sm">

--- a/entrypoints/match.content/caller.ts
+++ b/entrypoints/match.content/caller.ts
@@ -582,7 +582,12 @@ async function processGameData(gameData: IGameData, oldGameData: IGameData, from
         }
       }
       // Only play points sound if there's more than one player
-      playSound(points.toString());
+      const hasCombinedSound = config.caller.preferCombinedThrows && config.caller.sounds?.some(sound =>
+        sound.enabled && sound.triggers && sound.triggers.includes(combinedThrows),
+      );
+      if (!hasCombinedSound) {
+        playSound(points.toString());
+      }
       playSound(combinedThrows);
     } else {
       if (config.caller.callEveryDart) {

--- a/utils/storage.ts
+++ b/utils/storage.ts
@@ -117,6 +117,7 @@ export interface IConfig {
     enabled: boolean;
     callEveryDart: boolean;
     callCheckout: boolean;
+    preferCombinedThrows: boolean;
     sounds: ISound[];
   };
   soundFx: {
@@ -405,6 +406,7 @@ export const defaultConfig: IConfig = {
     enabled: false,
     callEveryDart: false,
     callCheckout: false,
+    preferCombinedThrows: false,
     sounds: [],
   },
   sounds: {


### PR DESCRIPTION
﻿## Summary

Adds a new optional caller toggle, **Prefer combined throws**, that suppresses the generic points sound (e.g. `26`) when an enabled caller sound exists for the exact dart combination (e.g. `s20_s5_s1`).

Today, when a player throws `s20 + s5 + s1`, the caller plays *both* `26` *and* `s20_s5_s1` back-to-back (see `entrypoints/match.content/caller.ts` around the `isLastThrow` branch). Users who set up specific sounds for memorable combinations end up with the points sound queued in front of them, which they cannot avoid without removing the `26` sound entirely (which would also silence every other 26-point throw).

The new option is **off by default**, so existing setups behave exactly as before.

## Motivation

It should be possible to play a dedicated sound for a specific dart combination without the generic score sound playing on top of it.

## How it works

In the last-throw branch of `processGameData` (non-Cricket), before calling `playSound(points.toString())`:

- If `config.caller.preferCombinedThrows` is enabled **and** an enabled caller sound has a trigger matching the current `combinedThrows` string, the points sound is skipped.
- Otherwise, behavior is identical to today.

The combined-throws sound itself is still played in both cases. Cricket logic is untouched (it does not use `points` / `combinedThrows` triggers in the same way).

## Changes

- `utils/storage.ts` — adds `preferCombinedThrows: boolean` to `IConfig.caller` plus default `false` in `defaultConfig`
- `entrypoints/match.content/caller.ts` — guards the `playSound(points.toString())` call with the new option + sound-existence check
- `components/Settings/Caller.vue` — new toggle next to **Call every dart** / **Call checkout**, styled identically
- `README.md` — one-line entry under the Caller "Configuration Options" section

Diff: 4 files, +19 / -1.

## Test plan

- [ ] `yarn compile` passes
- [ ] Toggle **off** (default): throwing `s20 + s5 + s1` plays both `26` and `s20_s5_s1` — unchanged from current behavior
- [ ] Toggle **on**, with sounds for both `26` and `s20_s5_s1`: throwing `s20 + s5 + s1` plays only `s20_s5_s1`
- [ ] Toggle **on**, with a sound only for `26` (no matching combined sound): throwing any 26-point combination still plays `26`
- [ ] Verify nothing changes in Cricket mode

## Notes for the maintainer

- Kept the change minimal and additive — no refactors, no touching of unrelated code paths.
- The same double-trigger pattern exists in `sound-fx.ts` (`ambient_${points}` + `ambient_${combinedThrows}`). I intentionally left that alone to keep this PR focused on the caller; happy to follow up with a sibling option for Sound FX if you''d like.
- Defaulting to `false` means zero behavior change for existing users.

Thanks for the great project! 🎯
