### PR TITLE
Add bulloff trigger support to caller

### DIFF
--- a/entrypoints/match.content/caller.ts
+++ b/entrypoints/match.content/caller.ts
@@ -30,13 +30,19 @@ let bullOffSoundPlayedForCurrentStart = false;
 // playback from websocket updates, player switches, or multiple content-script instances.
 const BULLOFF_SOUND_COOLDOWN_MS = 60 * 60 * 1000;
 const BULLOFF_STORAGE_LOCK_MS = 60 * 60 * 1000;
-const BULLOFF_START_STORAGE_KEY = "adt-tools-caller-bulloff-v6-matchdata-only";
+const BULLOFF_START_STORAGE_KEY = "adt-tools-caller-bulloff";
 // Flag to track if we've shown the interaction notification
 let interactionNotificationShown = false;
 // Reference to notification element
 let notificationElement: HTMLElement | null = null;
 // Reference to the style element for notification
 let notificationStyleElement: HTMLStyleElement | null = null;
+
+// Bull-off center-screen popup state
+let bullOffPopupElement: HTMLElement | null = null;
+let bullOffPopupStyleElement: HTMLStyleElement | null = null;
+let bullOffPopupTimer: number | null = null;
+const BULLOFF_POPUP_DURATION_MS = 3500;
 
 // Audio element pool for Safari compatibility
 const AUDIO_POOL_SIZE = 3;
@@ -66,7 +72,7 @@ function checkBoardStatus(boardData: IBoard): void {
 }
 
 export async function caller() {
-  console.log("Autodarts Tools: caller BULLOFF_V6_MATCHDATA_ONLY_NO_DOM");
+  console.log("Autodarts Tools: caller");
 
   try {
     config = await AutodartsToolsConfig.getValue();
@@ -177,6 +183,9 @@ export function callerOnRemove() {
 
   // Remove notification elements if they exist
   removeInteractionNotification();
+
+  // Remove Bull-off popup if it is currently visible
+  removeBullOffPopup();
 }
 
 /**
@@ -398,6 +407,102 @@ function removeInteractionNotification(): void {
   interactionNotificationShown = false;
 }
 
+function showBullOffPopup(): void {
+  try {
+    removeBullOffPopup();
+
+    if (!document.querySelector("style[data-adt-bulloff-popup-style]")) {
+      bullOffPopupStyleElement = document.createElement("style");
+      bullOffPopupStyleElement.setAttribute("data-adt-bulloff-popup-style", "");
+      bullOffPopupStyleElement.textContent = `
+        .adt-bulloff-popup {
+          position: fixed;
+          inset: 0;
+          z-index: 2147483647;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          pointer-events: none;
+          font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        }
+
+        .adt-bulloff-popup-text {
+          padding: 0.35em 0.75em;
+          border-radius: 0.22em;
+          color: #fff;
+          background: rgba(0, 0, 0, 0.72);
+          border: 0.06em solid rgba(255, 255, 255, 0.35);
+          box-shadow: 0 0.15em 1em rgba(0, 0, 0, 0.45), 0 0 1.5em rgba(255, 255, 255, 0.2);
+          font-size: clamp(3rem, 9vw, 8rem);
+          font-weight: 900;
+          letter-spacing: 0.05em;
+          line-height: 1;
+          text-transform: uppercase;
+          text-shadow: 0 0 0.18em rgba(255, 255, 255, 0.65), 0 0.05em 0.16em rgba(0, 0, 0, 0.85);
+          animation: adt-bulloff-popup-in 420ms ease-out both, adt-bulloff-popup-out 650ms ease-in 2850ms forwards;
+        }
+
+        @keyframes adt-bulloff-popup-in {
+          0% {
+            opacity: 0;
+            transform: scale(0.55) translateY(0.18em);
+            filter: blur(0.08em);
+          }
+          65% {
+            opacity: 1;
+            transform: scale(1.08) translateY(0);
+            filter: blur(0);
+          }
+          100% {
+            opacity: 1;
+            transform: scale(1);
+            filter: blur(0);
+          }
+        }
+
+        @keyframes adt-bulloff-popup-out {
+          to {
+            opacity: 0;
+            transform: scale(1.16) translateY(-0.08em);
+            filter: blur(0.05em);
+          }
+        }
+      `;
+      document.head.appendChild(bullOffPopupStyleElement);
+    } else {
+      bullOffPopupStyleElement = document.querySelector("style[data-adt-bulloff-popup-style]");
+    }
+
+    bullOffPopupElement = document.createElement("div");
+    bullOffPopupElement.className = "adt-bulloff-popup";
+    bullOffPopupElement.setAttribute("role", "status");
+    bullOffPopupElement.setAttribute("aria-live", "polite");
+    bullOffPopupElement.innerHTML = `<div class="adt-bulloff-popup-text">Bull-Off</div>`;
+    document.body.appendChild(bullOffPopupElement);
+
+    bullOffPopupTimer = window.setTimeout(removeBullOffPopup, BULLOFF_POPUP_DURATION_MS);
+  } catch (error) {
+    console.warn("Autodarts Tools: Could not show Bull-off popup", error);
+  }
+}
+
+function removeBullOffPopup(): void {
+  if (bullOffPopupTimer) {
+    window.clearTimeout(bullOffPopupTimer);
+    bullOffPopupTimer = null;
+  }
+
+  if (bullOffPopupElement) {
+    bullOffPopupElement.remove();
+    bullOffPopupElement = null;
+  }
+
+  if (bullOffPopupStyleElement && !document.querySelector(".adt-bulloff-popup")) {
+    bullOffPopupStyleElement.remove();
+    bullOffPopupStyleElement = null;
+  }
+}
+
 // Helper function to check if a sound trigger is already in queue
 function isSoundInQueue(trigger: string): boolean {
   // Find all sounds that match the trigger from config
@@ -510,7 +615,8 @@ function triggerBullOffCallerSound(triggerKey: string): void {
   bullOffSoundPlayedForCurrentStart = true;
   setBullOffSessionLock(triggerKey, now);
 
-  console.log("Autodarts Tools: BULLOFF_V6_MATCHDATA_ONLY_NO_DOM playing caller trigger bulloff", triggerKey);
+  console.log("Autodarts Tools: Bull-off detected, playing caller trigger bulloff and showing popup", triggerKey);
+  showBullOffPopup();
   playSound("bulloff");
 }
 /**

--- a/entrypoints/match.content/caller.ts
+++ b/entrypoints/match.content/caller.ts
@@ -1,3 +1,4 @@
+import { AutodartsToolsBoardData, type IBoard } from "@/utils/board-data-storage";
 import { AutodartsToolsGameData, type IGameData } from "@/utils/game-data-storage";
 import { AutodartsToolsConfig, type IConfig, type ISoundTTS } from "@/utils/storage";
 import { getSoundFromIndexedDB, isIndexedDBAvailable, triggerPatterns } from "@/utils/helpers";
@@ -21,6 +22,15 @@ const DEBOUNCE_DELAY = 200;
 // Cooldown tracking for gameshot/matchshot sounds (to prevent multiple triggers from AI referee)
 let lastGameshotTimestamp: number = 0;
 const GAMESHOT_COOLDOWN_MS = 10000; // 10 seconds cooldown
+// Track Bull-off sound trigger so it only plays once per Bull-off/match
+let lastBullOffTriggerKey: string | null = null;
+let lastBullOffTimestamp: number = 0;
+let bullOffSoundPlayedForCurrentStart = false;
+// Keep the Bull-off caller locked for the current match/page. This prevents duplicate
+// playback from websocket updates, player switches, or multiple content-script instances.
+const BULLOFF_SOUND_COOLDOWN_MS = 60 * 60 * 1000;
+const BULLOFF_STORAGE_LOCK_MS = 60 * 60 * 1000;
+const BULLOFF_START_STORAGE_KEY = "adt-tools-caller-bulloff-v6-matchdata-only";
 // Flag to track if we've shown the interaction notification
 let interactionNotificationShown = false;
 // Reference to notification element
@@ -56,7 +66,7 @@ function checkBoardStatus(boardData: IBoard): void {
 }
 
 export async function caller() {
-  console.log("Autodarts Tools: caller");
+  console.log("Autodarts Tools: caller BULLOFF_V6_MATCHDATA_ONLY_NO_DOM");
 
   try {
     config = await AutodartsToolsConfig.getValue();
@@ -65,6 +75,10 @@ export async function caller() {
 
     // Initialize audio player for Safari compatibility
     initAudioPlayer();
+
+    // Bull-off is handled only through game data.
+    // The previous click fallback could also fire on the Start Bull-off action,
+    // causing the same caller sound to be queued twice.
 
     if (!gameDataWatcherUnwatch) {
       gameDataWatcherUnwatch = AutodartsToolsGameData.watch((gameData: IGameData, oldGameData: IGameData) => {
@@ -119,8 +133,17 @@ export function callerOnRemove() {
     debounceTimer = null;
   }
 
+  // Bull-off is locked per match in sessionStorage.
+
   // Reset gameshot cooldown timestamp
   lastGameshotTimestamp = 0;
+
+  // Reset in-memory Bull-off trigger tracking. Do not clear the session lock here:
+  // Autodarts can re-initialize the caller while Bull-off is starting or switching players.
+  // Clearing the lock here would allow the same Bull-off start to trigger again.
+  lastBullOffTriggerKey = null;
+  lastBullOffTimestamp = 0;
+  bullOffSoundPlayedForCurrentStart = false;
 
   // Cancel any ongoing TTS
   if (window.speechSynthesis) {
@@ -327,7 +350,7 @@ function showInteractionNotification(): void {
           Please interact with the page (click, tap, or press a key) to enable audio for the caller.
         </div>
         <button class="adt-notification-close">
-          <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><!-- Icon from Pixelarticons by Gerrit Halfmann - https://github.com/halfmage/pixelarticons/blob/master/LICENSE --><path fill="currentColor" d="M5 5h2v2H5zm4 4H7V7h2zm2 2H9V9h2zm2 0h-2v2H9v2H7v2H5v2h2v-2h2v-2h2v-2h2v2h2v2h2v2h2v-2h-2v-2h-2v-2h-2zm2-2v2h-2V9zm2-2v2h-2V7zm0 0V5h2v2z"/></svg>
+          <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path fill="currentColor" d="M5 5h2v2H5zm4 4H7V7h2zm2 2H9V9h2zm2 0h-2v2H9v2H7v2H5v2h2v-2h2v-2h2v-2h2v2h2v2h2v2h2v-2h-2v-2h-2v-2h-2zm2-2v2h-2V9zm2-2v2h-2V7zm0 0V5h2v2z"/></svg>
         </button>
       </div>
     `;
@@ -392,12 +415,110 @@ function isSoundInQueue(trigger: string): boolean {
   );
 }
 
+
+function normalizeBullOffText(value: unknown): string {
+  return String(value ?? "").toLowerCase().replace(/[\s_-]+/g, "");
+}
+
+function textContainsBullOff(value: unknown): boolean {
+  const text = String(value ?? "").toLowerCase();
+  return text.includes("bull-off") || text.includes("bull off") || text.includes("bulloff");
+}
+
+function isBullOffActiveInGameData(gameData?: IGameData): boolean {
+  const match: any = gameData?.match;
+  if (!match) return false;
+
+  const directValues = [
+    match.variant,
+    match.type,
+    match.settings?.mode,
+    match.settings?.gameMode,
+    match.settings?.variant,
+    match.state?.variant,
+    match.state?.type,
+    match.state?.mode,
+    match.body?.variant,
+    match.body?.type,
+  ];
+
+  if (directValues.some(value => normalizeBullOffText(value) === "bulloff")) return true;
+
+  // Fallback: some Autodarts Bull-off states are nested in state/body while the outer match stays X01.
+  const stateText = JSON.stringify(match.state ?? {}).toLowerCase();
+  const bodyText = JSON.stringify(match.body ?? {}).toLowerCase();
+  return textContainsBullOff(stateText) || textContainsBullOff(bodyText);
+}
+
+function getBullOffTriggerKey(gameData?: IGameData): string {
+  const match: any = gameData?.match;
+
+  // Important: do not include round, player, turn, or throw data in this key.
+  // During Bull-off those values can change when the next player is selected,
+  // which would make the caller think a new Bull-off has started.
+  const matchIdFromUrl = window.location.href.match(/matches\/([0-9a-f-]+)/)?.[1];
+  const matchId = matchIdFromUrl ?? match?.id ?? window.location.pathname;
+
+  return `bulloff:${matchId}`;
+}
+type BullOffSessionLock = { key: string; timestamp: number };
+
+function getBullOffSessionLock(): BullOffSessionLock | null {
+  try {
+    const rawValue = window.sessionStorage.getItem(BULLOFF_START_STORAGE_KEY);
+    if (!rawValue) return null;
+
+    const parsedValue = JSON.parse(rawValue) as Partial<BullOffSessionLock>;
+    if (!parsedValue.key || !parsedValue.timestamp) return null;
+
+    return {
+      key: parsedValue.key,
+      timestamp: Number(parsedValue.timestamp),
+    };
+  } catch (error) {
+    console.warn("Autodarts Tools: Could not read Bull-off session lock", error);
+    return null;
+  }
+}
+
+function setBullOffSessionLock(triggerKey: string, timestamp: number): void {
+  try {
+    window.sessionStorage.setItem(BULLOFF_START_STORAGE_KEY, JSON.stringify({ key: triggerKey, timestamp }));
+  } catch (error) {
+    console.warn("Autodarts Tools: Could not write Bull-off session lock", error);
+  }
+}
+
+function triggerBullOffCallerSound(triggerKey: string): void {
+  const now = Date.now();
+  const sessionLock = getBullOffSessionLock();
+
+  // Stop duplicates from the same Bull-off start. This intentionally ignores
+  // source/round/player so websocket repeats and player switches cannot each
+  // play the sound.
+  if (
+    bullOffSoundPlayedForCurrentStart
+    || lastBullOffTriggerKey === triggerKey
+    || (sessionLock && sessionLock.key === triggerKey && now - sessionLock.timestamp < BULLOFF_STORAGE_LOCK_MS)
+    || now - lastBullOffTimestamp < 30000
+  ) {
+    return;
+  }
+
+  lastBullOffTriggerKey = triggerKey;
+  lastBullOffTimestamp = now;
+  bullOffSoundPlayedForCurrentStart = true;
+  setBullOffSessionLock(triggerKey, now);
+
+  console.log("Autodarts Tools: BULLOFF_V6_MATCHDATA_ONLY_NO_DOM playing caller trigger bulloff", triggerKey);
+  playSound("bulloff");
+}
 /**
  * Process game data to trigger sounds based on game events
  */
 let lastScore: number = 0;
 async function processGameData(gameData: IGameData, oldGameData: IGameData, fromWebSocket: boolean = false): Promise<void> {
-  if (!gameData.match || !gameData.match.turns?.length) return;
+  if (!gameData.match) return;
 
   const editMode: boolean = gameData.match.activated !== undefined && gameData.match.activated >= 0;
   if (editMode) {
@@ -406,7 +527,19 @@ async function processGameData(gameData: IGameData, oldGameData: IGameData, from
     return;
   }
 
-  if (gameData.match.variant === "Bull-off") return;
+  const bullOffActiveInGameData = isBullOffActiveInGameData(gameData);
+
+  if (bullOffActiveInGameData) {
+    // Always route Bull-off updates through the same match-level lock.
+    // The lock prevents duplicate playback on websocket repeats and player switches.
+    triggerBullOffCallerSound(getBullOffTriggerKey(gameData));
+    return;
+  }
+
+  // Do not reset the Bull-off lock here. During Bull-off, normal match/player updates can
+  // still arrive and would otherwise retrigger the start sound on player switches.
+
+  if (!gameData.match.turns?.length) return;
 
   // This is for cricket to prevent playing the score when not changed since last round
   if (gameData.match.turns[0].throws.length === 0) {
@@ -673,6 +806,11 @@ async function processGameData(gameData: IGameData, oldGameData: IGameData, from
 function playSound(trigger: string): void {
   console.log("Autodarts Tools: Adding sound to queue", trigger);
 
+  if (trigger === "bulloff" && isSoundInQueue("bulloff")) {
+    console.log("Autodarts Tools: Bull-off sound is already queued, skipping duplicate");
+    return;
+  }
+
   if (!config?.caller?.sounds || !config.caller.sounds.length) {
     console.log("Autodarts Tools: No sounds configured");
     return;
@@ -929,6 +1067,16 @@ async function playNextSound(): Promise<void> {
   // If the queue is empty, we're done
   if (soundQueue.length === 0) {
     isPlaying = false;
+    return;
+  }
+
+  // Browser autoplay rules can block the first sound on a newly opened match page.
+  // Keep the sound in the queue until the user clicks/taps/presses a key, instead of
+  // shifting it from the queue and losing it when audio playback is rejected.
+  if (!audioUnlocked) {
+    console.log("Autodarts Tools: Audio not unlocked yet, keeping sound in queue");
+    isPlaying = false;
+    showInteractionNotification();
     return;
   }
 

--- a/utils/websocket-helpers.ts
+++ b/utils/websocket-helpers.ts
@@ -218,10 +218,29 @@ export async function processWebSocketMessage(channel: string, data: ILobbies | 
       if (data.body) return;
 
       const id = window.location.href.match(/matches\/([0-9a-f-]+)/)?.[1];
-      const playersBoard = data.players?.find(player => player.boardId === window.location.href.match(/boards\/([0-9a-f-]+)/)?.[1]);
-      if ((id !== data.id && !playersBoard) && (data as IMatch).activated === undefined) return;
+      const boardId = window.location.href.match(/boards\/([0-9a-f-]+)/)?.[1];
+
+      const playersBoard = data.players?.find(player => player.boardId === boardId);
 
       const gameData = await AutodartsToolsGameData.getValue();
+
+      const isBullOff = (data as IMatch).variant === "Bull-off";
+      const currentPlayers = gameData.match?.players ?? [];
+      const incomingPlayers = (data as IMatch).players ?? [];
+
+      const isRelatedBullOff = isBullOff && currentPlayers.some(currentPlayer =>
+      incomingPlayers.some(incomingPlayer =>
+       (!!currentPlayer.id && currentPlayer.id === incomingPlayer.id)
+    || (!!currentPlayer.userId && currentPlayer.userId === incomingPlayer.userId)
+    || (!!currentPlayer.boardId && currentPlayer.boardId === incomingPlayer.boardId),
+  ),
+);
+
+if (isRelatedBullOff) {
+  console.log("Autodarts Tools: Related Bull-off accepted for current match", (data as IMatch).id);
+}
+
+if ((id !== data.id && !playersBoard && !isRelatedBullOff) && (data as IMatch).activated === undefined) return;
       if ((data as IMatch).activated !== undefined) {
         // Merge activated state with existing match data
         AutodartsToolsGameData.setValue({


### PR DESCRIPTION
## Summary

Adds support for using the existing `bulloff` trigger in the Caller feature.

This allows users to assign a custom caller sound that plays once when the Bull-off game starts.

## Why

The WLED integration already supports a `bulloff` trigger, but the Caller did not play a sound for Bull-off. This change makes it possible to use the same trigger name in Caller settings.

## Behavior

- Plays the caller sound with trigger `bulloff` when Bull-off starts.
- Prevents the sound from repeating during Bull-off player changes.
- Keeps normal Caller behavior unchanged for X01, Cricket, checkout sounds, player sounds, gameshot, matchshot, etc.

## Tested

Tested locally with a custom unpacked Chrome extension build:

- `yarn build` succeeds.
- Custom caller sound with trigger `bulloff` plays once when Bull-off starts.
- Sound does not repeat when switching to the next Bull-off player.

Update:

This PR now also shows a short animated "Bull-Off" popup in the center of the screen when the Bull-off game starts.

Additional behavior:
- Shows the popup once when Bull-off starts.
- Keeps the existing `bulloff` caller sound behavior.
- Does not repeat the sound or popup when switching Bull-off players.