### PR TITLE
gotcha: fix anchor after AD update

### DIFF
--- a/entrypoints/match.content/Gotcha.vue
+++ b/entrypoints/match.content/Gotcha.vue
@@ -60,6 +60,9 @@ function calculateDartThrow(targetScore: number): number | string {
 
 <style>
 .gotcha {
+  display: flex;
+  justify-content: center;
+  width: 100%;
   font-size: 3em;
   font-weight: 600;
   margin-top: 0;

--- a/entrypoints/match.content/index.ts
+++ b/entrypoints/match.content/index.ts
@@ -423,8 +423,7 @@ async function initGotcha(ctx) {
       {
         name: "autodarts-tools-gotcha",
         position: "inline",
-        anchor: `#${e.id} > div:first-of-type > p:first-of-type`,
-        append: 'after',
+        anchor: `#${e.id} .ad-ext-player-score`,
         onMount: (container: any) => {
           console.log("Autodarts Tools: Gotcha: initialized");
           const app = createApp(Gotcha, { playerIndex: index });


### PR DESCRIPTION
After a recent AD update the Gotcha Helper didn't work anymore. This patch adopts to the changed DOM.