### PR TITLE
🐛 Fix memory leaks causing Firefox crashes in long sessions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,17 @@ WXT + Vite plugins auto-import:
 
 Do **not** import these manually — they are globally available.
 
+### Build Notes
+
+- Path aliases `@`, `~`, and `src` all resolve to the repo root (set in `wxt.config.ts`)
+- Production builds strip all `console.*` and `debugger` statements (esbuild `drop`) — console logging only works in dev mode
+
+### Companion Services (separate sub-projects, not part of the extension build)
+
+- **`socket/`** — Socket.io server (Bun) deployed at `adt-socket.tobias-thiele.de`; tracks online friends/presence data shared between extension users
+- **`proxy/`** — Express server (Docker) that forwards Discord webhook requests via an `x-target-url` header
+- **`scripts/`** — Release automation (Safari/Xcode builds, App Store submission, AltStore source updates — see `scripts/README.md`)
+
 ## Code Conventions
 
 ### Vue Component Order
@@ -119,6 +130,8 @@ Version bump in `package.json` triggers the CI pipeline (`.github/workflows/rele
 2. Builds Safari extension → IPA uploaded to release
 3. Signs and submits to App Store (main branch only)
 4. Auto-updates AltStore source JSON
+
+Update `CHANGELOG.md` alongside the version bump.
 
 ## Key Files
 

--- a/entrypoints/lobby.content/discord-webhooks.ts
+++ b/entrypoints/lobby.content/discord-webhooks.ts
@@ -15,6 +15,8 @@ let webhookUrl: string | null = null;
 let storedLobbyFields: Array<{ name: string; value: string; inline: boolean }> = [];
 // Flag to prevent duplicate message updates
 let messageUpdated = false;
+// Observer watching for the Start Game button
+let startButtonObserver: MutationObserver | null = null;
 
 export async function discordWebhooks() {
   console.log("Autodarts Tools: Discord Webhooks - Starting");
@@ -33,9 +35,12 @@ export async function discordWebhooks() {
 
     if (!refreshButton) return;
 
+    if (lobbyBoardSelectParentElement.querySelector("#adt-discord-webhook-button")) return;
+
     // create a copy of the refresh button and add "D" as text content
     // then add the new button to the parent element
     const discordButton = refreshButton.cloneNode() as HTMLButtonElement;
+    discordButton.id = "adt-discord-webhook-button";
     discordButton.innerHTML = iconDiscord;
     discordButton.title = "Send Discord Webhook";
 
@@ -116,6 +121,9 @@ export async function discordWebhooks() {
 
 // Function to set up a mutation observer to watch for the Start Game button
 function setupStartButtonListener() {
+  // Disconnect any observer from a previous lobby before creating a new one
+  startButtonObserver?.disconnect();
+
   // Create a MutationObserver to watch for button additions to the DOM
   const observer = new MutationObserver((mutations) => {
     for (const mutation of mutations) {
@@ -140,6 +148,7 @@ function setupStartButtonListener() {
 
   // Start observing the document body for changes
   observer.observe(document.body, { childList: true, subtree: true });
+  startButtonObserver = observer;
 
   // Check for existing buttons
   const existingStartButtons = Array.from(document.querySelectorAll("button")).filter(
@@ -154,6 +163,18 @@ function setupStartButtonListener() {
         console.log("Autodarts Tools: Discord Webhooks - Added listener to existing Start Game button");
       }
     });
+  }
+}
+
+export function discordWebhooksOnRemove() {
+  if (startButtonObserver) {
+    startButtonObserver.disconnect();
+    startButtonObserver = null;
+  }
+
+  if (autoStartTimer !== null) {
+    clearTimeout(autoStartTimer);
+    autoStartTimer = null;
   }
 }
 

--- a/entrypoints/lobby.content/index.ts
+++ b/entrypoints/lobby.content/index.ts
@@ -4,7 +4,7 @@ import { createApp } from "vue";
 import { soundFx, soundFxOnRemove } from "../match.content/sound-fx";
 import { wledFx, wledFxOnRemove } from "../match.content/wled";
 
-import { teamLobby } from "./team-lobby";
+import { teamLobby, teamLobbyOnRemove } from "./team-lobby";
 
 import type { IConfig } from "@/utils/storage";
 
@@ -13,7 +13,7 @@ import {
   AutodartsToolsConfig,
   AutodartsToolsUrlStatus,
 } from "@/utils/storage";
-import { discordWebhooks } from "@/entrypoints/lobby.content/discord-webhooks";
+import { discordWebhooks, discordWebhooksOnRemove } from "@/entrypoints/lobby.content/discord-webhooks";
 import { autoStart, onRemove as onAutoStartRemove } from "@/entrypoints/lobby.content/auto-start";
 import { onRemove as onShufflePlayersRemove, shufflePlayers } from "@/entrypoints/lobby.content/shuffle-players";
 import { onRemove as onQrCodeRemove, qrCode } from "@/entrypoints/lobbynew.content/qr-code";
@@ -115,6 +115,8 @@ export default defineContentScript({
         await onQrCodeRemove();
         await soundFxOnRemove();
         await wledFxOnRemove();
+        discordWebhooksOnRemove();
+        await teamLobbyOnRemove();
       }
     });
   },

--- a/entrypoints/lobby.content/shuffle-players.ts
+++ b/entrypoints/lobby.content/shuffle-players.ts
@@ -7,6 +7,9 @@ let shuffledPlayerNames: string[] = [];
 export async function shufflePlayers() {
   try {
     const buttonsContainer = await waitForElement("#root > div > div:nth-of-type(2) > div > div:nth-of-type(2) > div:nth-of-type(2) > div:nth-of-type(2) > div:last-of-type") as HTMLDivElement;
+
+    if (document.querySelector("#autodarts-tools-shuffle-button")) return;
+
     const button = buttonsContainer.querySelector("button")?.cloneNode(true) as HTMLButtonElement;
 
     button.id = "autodarts-tools-shuffle-button";
@@ -18,6 +21,7 @@ export async function shufflePlayers() {
 
     button.addEventListener("click", handleShuffle);
 
+    if (checkPlayersInterval) clearInterval(checkPlayersInterval);
     checkPlayersInterval = setInterval(checkPlayers, 500);
 
     buttonsContainer.appendChild(button);

--- a/entrypoints/lobby.content/team-lobby.ts
+++ b/entrypoints/lobby.content/team-lobby.ts
@@ -16,6 +16,7 @@ export async function teamLobby() {
     const lobbyData = await AutodartsToolsLobbyData.getValue();
     if (lobbyData?.isPrivate) {
       processTeamLobby(lobbyData).catch(console.error);
+      lobbyDataWatcherUnwatch?.();
       lobbyDataWatcherUnwatch = AutodartsToolsLobbyData.watch((data: ILobbies | undefined) => {
         if (!data) return;
         processTeamLobby(data).catch(console.error);
@@ -73,6 +74,7 @@ async function processTeamLobby(lobbyStatus: ILobbyStatus) {
 
 export async function teamLobbyOnRemove() {
   lobbyDataWatcherUnwatch?.();
+  lobbyDataWatcherUnwatch = null;
   // Reset the flag when the lobby is removed
   hostAlreadyRemoved = false;
 }

--- a/entrypoints/lobbynew.content/index.ts
+++ b/entrypoints/lobbynew.content/index.ts
@@ -35,21 +35,27 @@ export default defineContentScript({
 
         console.log("Autodarts Tools: Game Mode", gameModeTitle.textContent);
 
-        buttonPublic?.addEventListener("click", async () => {
-          await AutodartsToolsGameData.setValue({
-            ...gameData,
-            private: false,
+        if (buttonPublic && !buttonPublic.hasAttribute("data-adt-visibility-listener")) {
+          buttonPublic.setAttribute("data-adt-visibility-listener", "true");
+          buttonPublic.addEventListener("click", async () => {
+            await AutodartsToolsGameData.setValue({
+              ...gameData,
+              private: false,
+            });
+            console.log("Autodarts Tools: Lobby is Public");
           });
-          console.log("Autodarts Tools: Lobby is Public");
-        });
+        }
 
-        buttonPrivate?.addEventListener("click", async () => {
-          await AutodartsToolsGameData.setValue({
-            ...gameData,
-            private: true,
+        if (buttonPrivate && !buttonPrivate.hasAttribute("data-adt-visibility-listener")) {
+          buttonPrivate.setAttribute("data-adt-visibility-listener", "true");
+          buttonPrivate.addEventListener("click", async () => {
+            await AutodartsToolsGameData.setValue({
+              ...gameData,
+              private: true,
+            });
+            console.log("Autodarts Tools: Lobby is Private");
           });
-          console.log("Autodarts Tools: Lobby is Private");
-        });
+        }
 
         // check if buttonPublic or buttonPrivate has data-active attribute and set the private state accordingly
         if (buttonPublic?.hasAttribute("data-active")) {

--- a/entrypoints/match.content/Animations.vue
+++ b/entrypoints/match.content/Animations.vue
@@ -35,6 +35,7 @@ const FADE_DURATION = 300; // ms
 const FADE_IN_DELAY = 50; // ms
 
 let updateInterval: NodeJS.Timeout | null = null;
+let gameDataUnwatch: (() => void) | null = null;
 
 // State
 const isShowingAnimation = ref(false);
@@ -83,7 +84,7 @@ onMounted(async () => {
 
   try {
     config.value = await AutodartsToolsConfig.getValue();
-    AutodartsToolsGameData.watch((gameData: IGameData) => {
+    gameDataUnwatch = AutodartsToolsGameData.watch((gameData: IGameData) => {
       processGameData(gameData);
     });
 
@@ -102,6 +103,9 @@ onMounted(async () => {
 
 // Clean up interval on unmount
 onUnmounted(() => {
+  gameDataUnwatch?.();
+  gameDataUnwatch = null;
+
   if (updateInterval) clearInterval(updateInterval);
   window.removeEventListener("resize", updateBoardPosition);
 

--- a/entrypoints/match.content/InstantReplay.vue
+++ b/entrypoints/match.content/InstantReplay.vue
@@ -54,6 +54,7 @@ const boardPosition = ref({
   height: 0,
 });
 let updateInterval: NodeJS.Timeout | null = null;
+let gameDataUnwatch: (() => void) | null = null;
 
 // Computed properties for camera settings
 const zoomLevel = computed(() => config.value?.instantReplay?.zoom || 1);
@@ -102,6 +103,10 @@ onMounted(async () => {
 });
 
 onUnmounted(() => {
+  // Stop listening for game data updates
+  gameDataUnwatch?.();
+  gameDataUnwatch = null;
+
   // Clean up camera and all resources first
   cleanup();
 
@@ -224,7 +229,8 @@ async function loadConfig() {
 }
 
 function setupGameDataWatcher() {
-  AutodartsToolsGameData.watch(async (gameData) => {
+  gameDataUnwatch?.();
+  gameDataUnwatch = AutodartsToolsGameData.watch(async (gameData) => {
     // Check if there's a winner
     if (gameData?.match && (gameData.match.winner !== -1 || gameData.match.gameWinner !== -1)) {
       // Clear any existing timeouts

--- a/entrypoints/match.content/StreamingMode.vue
+++ b/entrypoints/match.content/StreamingMode.vue
@@ -277,6 +277,9 @@ const currentBoardImage = ref<string>("");
 
 const streamingModeButton: Ref<HTMLAnchorElement | null> = ref(null);
 
+let gameDataUnwatch: (() => void) | null = null;
+let boardImagesUnwatch: (() => void) | null = null;
+
 const showAvg = computed(() => config.value?.streamingMode.avg);
 
 // Helper to get number of throws in current turn
@@ -411,7 +414,7 @@ onMounted(async () => {
   config.value = await AutodartsToolsConfig.getValue();
   gameData.value = await AutodartsToolsGameData.getValue();
 
-  AutodartsToolsGameData.watch((value) => {
+  gameDataUnwatch = AutodartsToolsGameData.watch((value) => {
     gameData.value = value;
 
     // Update game title when game data changes
@@ -419,7 +422,7 @@ onMounted(async () => {
   });
 
   // Set up board image watcher
-  AutodartsToolsBoardImages.watch((boardImages: IBoardImages) => {
+  boardImagesUnwatch = AutodartsToolsBoardImages.watch((boardImages: IBoardImages) => {
     if (boardImages.images.length > 0) {
       currentBoardImage.value = boardImages.images[boardImages.images.length - 1];
     }
@@ -475,6 +478,16 @@ watch([ coordsElementScale, scoreBoardScale, coordsElementX, coordsElementY, sco
   await AutodartsToolsConfig.setValue(toRaw(config.value!));
   console.log("Streaming Mode setting changed");
 }, { deep: true });
+
+onUnmounted(() => {
+  gameDataUnwatch?.();
+  gameDataUnwatch = null;
+
+  boardImagesUnwatch?.();
+  boardImagesUnwatch = null;
+
+  document.querySelector("#adt-stream-mode-button")?.remove();
+});
 
 // Helper function to update game title
 function updateGameTitle() {

--- a/entrypoints/match.content/Zoom.vue
+++ b/entrypoints/match.content/Zoom.vue
@@ -182,6 +182,9 @@ function setupResizeObserver() {
 }
 
 let resizeObserver: ResizeObserver | null = null;
+let boardImagesUnwatch: (() => void) | null = null;
+let gameDataUnwatch: (() => void) | null = null;
+let centerResizeHandler: (() => void) | null = null;
 
 function updateZoomDivs() {
   if (position.value !== "center") return;
@@ -301,7 +304,7 @@ onMounted(async () => {
   });
 
   if (config.value.zoom.mode === "live") {
-    AutodartsToolsBoardImages.watch((_boardImages: IBoardImages) => {
+    boardImagesUnwatch = AutodartsToolsBoardImages.watch((_boardImages: IBoardImages) => {
       const lastImage = _boardImages.images[_boardImages.images.length - 1];
       if (lastImage && throws.value > 0) boardImages.value[throws.value - 1] = lastImage;
 
@@ -313,7 +316,7 @@ onMounted(async () => {
   }
 
   // Also update the AutodartsToolsGameData.watch to call updateZoomDivs
-  AutodartsToolsGameData.watch(async (_gameData: IGameData, _previousGameData: IGameData) => {
+  gameDataUnwatch = AutodartsToolsGameData.watch(async (_gameData: IGameData, _previousGameData: IGameData) => {
     if (!_gameData.match?.turns?.length) return;
 
     // Store the game data for checkout availability checking
@@ -390,10 +393,23 @@ onUnmounted(() => {
   // Clean up event listeners and observers
   window.removeEventListener("resize", checkNavigationWidth);
 
+  if (centerResizeHandler) {
+    window.removeEventListener("resize", centerResizeHandler);
+    centerResizeHandler = null;
+  }
+
+  boardImagesUnwatch?.();
+  boardImagesUnwatch = null;
+
+  gameDataUnwatch?.();
+  gameDataUnwatch = null;
+
   if (resizeObserver) {
     resizeObserver.disconnect();
     resizeObserver = null;
   }
+
+  document.querySelector("#autodarts-tools-zoom-center")?.remove();
 });
 
 async function initCenterZoom() {
@@ -458,13 +474,17 @@ async function initCenterZoom() {
     leftPosition.value = rect.left;
 
     // Listen for window resize to update the position
-    window.addEventListener("resize", () => {
+    if (centerResizeHandler) {
+      window.removeEventListener("resize", centerResizeHandler);
+    }
+    centerResizeHandler = () => {
       const updatedTurnElement = document.querySelector("#ad-ext-turn");
       if (updatedTurnElement) {
         const updatedRect = updatedTurnElement.getBoundingClientRect();
         leftPosition.value = updatedRect.left;
       }
-    });
+    };
+    window.addEventListener("resize", centerResizeHandler);
   }
 }
 

--- a/entrypoints/match.content/automatic-fullscreen.ts
+++ b/entrypoints/match.content/automatic-fullscreen.ts
@@ -1,6 +1,8 @@
 import { waitForElement } from "@/utils";
 import { AutodartsToolsGameData } from "@/utils/game-data-storage";
 
+let fullscreenChangeHandler: (() => void) | null = null;
+
 export async function automaticFullscreen() {
   console.log("Autodarts Tools: Setting up automatic fullscreen");
 
@@ -92,10 +94,14 @@ export async function automaticFullscreen() {
     }
   };
 
-  fullscreenBtn.addEventListener("click", () => toggleFullscreen());
+  fullscreenBtn.onclick = () => toggleFullscreen();
 
-  // Listen for fullscreen change event to update button icon
-  document.addEventListener("fullscreenchange", () => {
+  // Listen for fullscreen change event to update button icon,
+  // replacing any handler left over from a previous init
+  if (fullscreenChangeHandler) {
+    document.removeEventListener("fullscreenchange", fullscreenChangeHandler);
+  }
+  fullscreenChangeHandler = () => {
     if (!document.fullscreenElement) {
       // Update SVG to show enter fullscreen icon when exiting fullscreen
       fullscreenBtnSVG.children[0].setAttribute(
@@ -111,7 +117,8 @@ export async function automaticFullscreen() {
       );
       isFullscreen = true;
     }
-  });
+  };
+  document.addEventListener("fullscreenchange", fullscreenChangeHandler);
 
   // Initial fullscreen activation when the feature is enabled
   toggleFullscreen(true);
@@ -122,6 +129,11 @@ export async function automaticFullscreenOnRemove() {
 
   const fullscreenBtn = document.querySelector("#adt-fullscreen-toggle");
   fullscreenBtn?.remove();
+
+  if (fullscreenChangeHandler) {
+    document.removeEventListener("fullscreenchange", fullscreenChangeHandler);
+    fullscreenChangeHandler = null;
+  }
 
   // Exit fullscreen mode if active
   if (document.fullscreenElement) {

--- a/entrypoints/match.content/next-player-on-take-out-stuck.ts
+++ b/entrypoints/match.content/next-player-on-take-out-stuck.ts
@@ -5,28 +5,13 @@ import { waitForElementWithTextContent } from "@/utils";
 import { AutodartsToolsBoardData } from "@/utils/board-data-storage";
 
 let boardDataWatcherUnwatch: any;
+let takeOutTimout: NodeJS.Timeout | undefined;
+let clickListenerAttached = false;
 
-// Create a map to store event listeners
-const eventListenersMap = new Map();
-
-// Create a wrapper around addEventListener
-// @ts-expect-error
-Document.prototype.realAddEventListener = Document.prototype.addEventListener;
-Document.prototype.addEventListener = function (eventName, callback) {
-// @ts-expect-error
-  this.realAddEventListener(eventName, callback);
-
-  if (!eventListenersMap.has(eventName)) {
-    eventListenersMap.set(eventName, []);
-  }
-
-  eventListenersMap.get(eventName).push(callback);
-};
-
-// Create a function to check if an event listener has been defined
-function hasEventListener(eventName, callback) {
-  const listeners = eventListenersMap.get(eventName);
-  return listeners && listeners.includes(callback);
+function removeCountdown() {
+  const element = document.getElementById("ad-ext_next-text");
+  element?.remove();
+  if (takeOutTimout) clearInterval(takeOutTimout);
 }
 
 export async function nextPlayerOnTakeOutStuck() {
@@ -35,33 +20,10 @@ export async function nextPlayerOnTakeOutStuck() {
 
     const config = await AutodartsToolsConfig.getValue();
 
-    let takeOutTimout: NodeJS.Timeout;
-
-    function remove() {
-      const element = document.getElementById("ad-ext_next-text");
-      element?.remove();
-      if (takeOutTimout) clearInterval(takeOutTimout);
-    }
-
-    // Make sure event listeners are properly registered and maintained in fullscreen mode
-    if (!hasEventListener("click", remove)) {
-      document.addEventListener("click", remove);
-    }
-
-    // Handle fullscreen changes
-    function handleFullscreenChange() {
-      if (document.fullscreenElement) {
-        console.log("Autodarts Tools: Fullscreen mode detected, ensuring next player on takeout stuck still works");
-        // Re-register click event if needed in fullscreen
-        if (!hasEventListener("click", remove)) {
-          document.addEventListener("click", remove);
-        }
-      }
-    }
-
-    // Add fullscreen change handler if not already present
-    if (!hasEventListener("fullscreenchange", handleFullscreenChange)) {
-      document.addEventListener("fullscreenchange", handleFullscreenChange);
+    // Document-level listeners keep working in fullscreen, so a single registration is enough
+    if (!clickListenerAttached) {
+      document.addEventListener("click", removeCountdown);
+      clickListenerAttached = true;
     }
 
     boardDataWatcherUnwatch?.();
@@ -121,7 +83,7 @@ export async function nextPlayerOnTakeOutStuck() {
         }, 1000);
       } else {
         if (takeOutTimout) clearInterval(takeOutTimout);
-        remove();
+        removeCountdown();
       }
     });
   } catch (e) {
@@ -132,23 +94,13 @@ export async function nextPlayerOnTakeOutStuck() {
 export function nextPlayerOnTakeOutStuckOnRemove() {
   if (boardDataWatcherUnwatch) {
     boardDataWatcherUnwatch();
+    boardDataWatcherUnwatch = null;
   }
 
-  // Clean up fullscreen event listener
-  const fullscreenHandler = eventListenersMap.get("fullscreenchange")?.find(
-    callback => callback.name === "handleFullscreenChange",
-  );
+  removeCountdown();
 
-  if (fullscreenHandler) {
-    document.removeEventListener("fullscreenchange", fullscreenHandler);
-  }
-
-  // Clean up click handler
-  const clickHandler = eventListenersMap.get("click")?.find(
-    callback => callback.name === "remove",
-  );
-
-  if (clickHandler) {
-    document.removeEventListener("click", clickHandler);
+  if (clickListenerAttached) {
+    document.removeEventListener("click", removeCountdown);
+    clickListenerAttached = false;
   }
 }


### PR DESCRIPTION
## Problem

On Firefox, long play sessions steadily grow memory until the browser crashes and takes a long time to recover. The content scripts accumulate listeners, observers, and storage watchers on every lobby/match navigation, and since autodarts.io is a SPA the content scripts live for the whole session — nothing is ever reclaimed.

## Root causes & fixes

### High severity

- **`next-player-on-take-out-stuck.ts`** monkeypatched `Document.prototype.addEventListener` globally and recorded **every listener the entire page ever registered** into a module-level map that was never pruned (`removeEventListener` was not intercepted). On a SPA that re-registers listeners constantly, this map and all closures it pinned grew without bound for the tab's lifetime. → Monkeypatch removed entirely; the feature tracks its own two listeners with plain references (document-level listeners survive fullscreen changes, so the re-registration hack was unnecessary).
- **`discord-webhooks.ts`** created a new `MutationObserver` over the whole `document.body` subtree on **every lobby entered** and never disconnected any of them — dozens of full-page observers firing on every DOM change after a few hours (memory + CPU). → Previous observer is disconnected before creating a new one, the injected button is deduped, and a new `discordWebhooksOnRemove()` (also cancels the auto-start timer) is wired into the lobby navigation cleanup.

### Per-match leaks (one more of each, every match played)

- **`StreamingMode.vue`, `Zoom.vue`, `Animations.vue`, `InstantReplay.vue`** registered `AutodartsToolsGameData` / `AutodartsToolsBoardImages` storage watchers in `onMounted` without ever unwatching. These components are unmounted/remounted per match, so each match added another set of watchers firing on **every dart thrown** while retaining the dead component instances. → Unwatch functions are stored and called on unmount. Zoom additionally leaked an anonymous window `resize` listener (center mode) and its cloned `#autodarts-tools-zoom-center` element; StreamingMode leaked its injected `#adt-stream-mode-button`. Both cleaned up.
- **`automatic-fullscreen.ts`** added a document `fullscreenchange` listener per match (two per Bull-off transition), each retaining detached SVG nodes. → Handler is tracked at module level and removed on cleanup and re-init.
- **`team-lobby.ts`** overwrote its lobby-data watcher handle without unwatching, and `teamLobbyOnRemove()` existed but was never called anywhere. → Unwatch before re-registering; onRemove wired into the lobby index.

### Low severity

- **`shuffle-players.ts`** could orphan its 500 ms polling interval and duplicate its button on repeated lobby inits. → Interval cleared before re-creating; button deduped by id.
- **`lobbynew.content/index.ts`** re-added click listeners to the Public/Private buttons on every create-lobby visit. → Deduped via a data attribute.

Also includes a small CLAUDE.md documentation update (companion services, build notes).

## Verification

- `yarn compile` (vue-tsc): **zero new errors** — the 15 pre-existing baseline errors on `main` are identical before and after (verified via `git stash` comparison).
- ESLint on all changed files: zero errors; remaining warnings are pre-existing.
- Recommended manual check: play several consecutive matches on Firefox with Discord webhooks / Streaming Mode / Zoom enabled and watch `about:memory` — usage should now stay flat instead of ratcheting up per match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)