### PR TITLE
Update references from autodarts.io to autodarts.com

### DIFF
--- a/Autodarts_Tools_Source.json
+++ b/Autodarts_Tools_Source.json
@@ -14,7 +14,7 @@
       "bundleIdentifier": "com.boltapi.autodarts-tools",
       "developerName": "Tobias Thiele",
       "subtitle": "Enhance your Autodarts experience",
-      "localizedDescription": "Tools for Autodarts is a browser extension that enhances your gaming experience on autodarts.io. It adds numerous quality-of-life features, customization options, and advanced functionality to make your Autodarts experience more enjoyable and personalized.",
+      "localizedDescription": "Tools for Autodarts is a browser extension that enhances your gaming experience on autodarts.com. It adds numerous quality-of-life features, customization options, and advanced functionality to make your Autodarts experience more enjoyable and personalized.",
       "iconURL": "https://i.imgur.com/I4ZLN8l.png",
       "tintColor": "#6156e2",
       "category": "entertainment",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,13 +4,13 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What This Is
 
-A browser extension (Chrome, Firefox, Safari/iOS) that enhances the gaming experience on autodarts.io. Built with **Vue 3**, **TypeScript**, **TailwindCSS**, and **WXT** (Web Extension Toolkit). Distributed via Chrome Web Store, Firefox Add-ons, App Store, and AltStore.
+A browser extension (Chrome, Firefox, Safari/iOS) that enhances the gaming experience on autodarts.com. Built with **Vue 3**, **TypeScript**, **TailwindCSS**, and **WXT** (Web Extension Toolkit). Distributed via Chrome Web Store, Firefox Add-ons, App Store, and AltStore.
 
 ## Commands
 
 ```bash
 yarn install            # Install dependencies (runs wxt prepare via postinstall)
-yarn dev                # Dev mode for Chrome (opens play.autodarts.io, Alt+T to reload)
+yarn dev                # Dev mode for Chrome (opens play.autodarts.com, Alt+T to reload)
 yarn dev:firefox        # Dev mode for Firefox
 yarn build              # Production build for Chrome
 yarn build:firefox      # Production build for Firefox
@@ -20,7 +20,7 @@ yarn zip:firefox        # Create Firefox distribution zip
 yarn compile            # TypeScript type-check (vue-tsc --noEmit)
 ```
 
-No test framework is configured — testing is manual on autodarts.io across Chrome and Firefox.
+No test framework is configured — testing is manual on autodarts.com across Chrome and Firefox.
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Tools for Autodarts
 
 ## 📋 Overview
 
-Tools for Autodarts is a browser extension that enhances your gaming experience on [autodarts.io](https://autodarts.io). It adds numerous quality-of-life features, customization options, and advanced functionality to make your Autodarts experience more enjoyable and personalized.
+Tools for Autodarts is a browser extension that enhances your gaming experience on [autodarts.com](https://autodarts.com). It adds numerous quality-of-life features, customization options, and advanced functionality to make your Autodarts experience more enjoyable and personalized.
 
 ## 💾 Installation
 
@@ -557,7 +557,7 @@ Give a star if this project helped you.
 
 ## 👏 Credits
 
-🎯 [Autodarts](https://autodarts.io) - The original platform this extension enhances<br>
+🎯 [Autodarts](https://autodarts.com) - The original platform this extension enhances<br>
 🎨 Benjamin Zehentner (Discord: ben_1987) - Creator of the Tools for Autodarts logo
 
 ## 📄 License

--- a/entrypoints/auth-cookie.ts
+++ b/entrypoints/auth-cookie.ts
@@ -25,11 +25,16 @@
 // Token-issuing endpoints whose JSON response contains an `access_token`.
 const TOKEN_ENDPOINTS = [
   // New OAuth 2.0 server (Authorization Code + PKCE)
+  "https://api.autodarts.com/auth/v1/exchange",
+  "https://api.autodarts.com/auth/v1/refresh",
+  "https://api.autodarts.com/auth/v1/token",
+  "https://api.autodarts.com/auth/v1/device/token",
   "https://api.autodarts.io/auth/v1/exchange",
   "https://api.autodarts.io/auth/v1/refresh",
   "https://api.autodarts.io/auth/v1/token",
   "https://api.autodarts.io/auth/v1/device/token",
-  // Legacy Keycloak — kept for the migration window (shutting down 2026-06-28)
+  // Legacy Keycloak — kept for the migration window
+  "https://login.autodarts.com/realms/autodarts/protocol/openid-connect/token",
   "https://login.autodarts.io/realms/autodarts/protocol/openid-connect/token",
 ];
 

--- a/entrypoints/boards.content/index.ts
+++ b/entrypoints/boards.content/index.ts
@@ -10,7 +10,7 @@ let externalBoardsUI: any;
 let boardsReadyUnwatch: any;
 
 export default defineContentScript({
-  matches: [ "*://play.autodarts.io/*" ],
+  matches: [ "*://play.autodarts.io/*", "*://play.autodarts.com/*" ],
   cssInjectionMode: "ui",
   async main(ctx: any) {
     boardsReadyUnwatch = AutodartsToolsUrlStatus.watch(async (url: string) => {

--- a/entrypoints/content/index.ts
+++ b/entrypoints/content/index.ts
@@ -12,7 +12,7 @@ import Migration from "@/components/Migration.vue";
 let migrationModalUI: any;
 
 export default defineContentScript({
-  matches: [ "*://play.autodarts.io/*" ],
+  matches: [ "*://play.autodarts.io/*", "*://play.autodarts.com/*" ],
   cssInjectionMode: "ui",
   async main(ctx) {
     await waitForElement("#root > div:nth-of-type(1)", 15000);

--- a/entrypoints/lobby.content/index.ts
+++ b/entrypoints/lobby.content/index.ts
@@ -43,7 +43,7 @@ export default defineContentScript({
 
           try {
             console.log("Autodarts Tools: Fetching lobby data with cookie authentication...");
-            const apiUrl = `https://api.autodarts.io/gs/v0/lobbies/${lobbyId}`;
+            const apiUrl = `https://api.autodarts.com/gs/v0/lobbies/${lobbyId}`;
             const response = await fetchWithAuth(apiUrl);
 
             console.log("Autodarts Tools: Response status:", response.status);

--- a/entrypoints/lobbynew.content/index.ts
+++ b/entrypoints/lobbynew.content/index.ts
@@ -13,7 +13,7 @@ import { waitForElement, waitForElementWithTextContent } from "@/utils";
 import { isSafari, isiOS } from "@/utils/helpers";
 
 export default defineContentScript({
-  matches: [ "*://play.autodarts.io/*" ],
+  matches: [ "*://play.autodarts.io/*", "*://play.autodarts.com/*" ],
   cssInjectionMode: "ui",
   async main() {
     AutodartsToolsUrlStatus.watch(async (url: string) => {

--- a/entrypoints/lobbynew.content/qr-code-options.ts
+++ b/entrypoints/lobbynew.content/qr-code-options.ts
@@ -3,7 +3,7 @@ export const QR_CODE_OPTIONS = {
   shape: "square",
   width: 300,
   height: 300,
-  data: "https://play.autodarts.io/lobbies/0196aa5d-3b34-7421-b326-8dd2e2ebd6d3",
+  data: "https://play.autodarts.com/lobbies/0196aa5d-3b34-7421-b326-8dd2e2ebd6d3",
   margin: 0,
   qrOptions: {
     typeNumber: "0",

--- a/entrypoints/match.content/QuickCorrection.vue
+++ b/entrypoints/match.content/QuickCorrection.vue
@@ -467,7 +467,7 @@ async function openCorrection(throwElement?: HTMLElement) {
   try {
     await browser.runtime.sendMessage({
       type: "fetch",
-      url: `https://api.autodarts.io/gs/v0/matches/${matchId}/corrections`,
+      url: `https://api.autodarts.com/gs/v0/matches/${matchId}/corrections`,
       options: {
         method: "POST",
         credentials: "include",
@@ -657,7 +657,7 @@ async function applyCorrection(value: string) {
       // Step 1: Activate the throw
       await browser.runtime.sendMessage({
         type: "fetch",
-        url: `https://api.autodarts.io/gs/v0/matches/${matchId}/corrections`,
+        url: `https://api.autodarts.com/gs/v0/matches/${matchId}/corrections`,
         options: {
           method: "POST",
           credentials: "include",
@@ -676,7 +676,7 @@ async function applyCorrection(value: string) {
         try {
           await browser.runtime.sendMessage({
             type: "fetch",
-            url: `https://api.autodarts.io/gs/v0/matches/${matchId}/corrections`,
+            url: `https://api.autodarts.com/gs/v0/matches/${matchId}/corrections`,
             options: {
               method: "POST",
               credentials: "include",
@@ -695,7 +695,7 @@ async function applyCorrection(value: string) {
             try {
               await browser.runtime.sendMessage({
                 type: "fetch",
-                url: `https://api.autodarts.io/gs/v0/matches/${matchId}/corrections`,
+                url: `https://api.autodarts.com/gs/v0/matches/${matchId}/corrections`,
                 options: {
                   method: "POST",
                   credentials: "include",
@@ -722,7 +722,7 @@ async function applyCorrection(value: string) {
 
                   await browser.runtime.sendMessage({
                     type: "fetch",
-                    url: `https://api.autodarts.io/gs/v0/matches/${matchId}/throws`,
+                    url: `https://api.autodarts.com/gs/v0/matches/${matchId}/throws`,
                     options: {
                       method: "PATCH",
                       credentials: "include",
@@ -820,7 +820,7 @@ async function applyCorrection(value: string) {
     // Send the correction
     const response = await browser.runtime.sendMessage({
       type: "fetch",
-      url: `https://api.autodarts.io/gs/v0/matches/${matchId}/corrections`,
+      url: `https://api.autodarts.com/gs/v0/matches/${matchId}/corrections`,
       options: {
         method: "POST",
         credentials: "include",
@@ -845,7 +845,7 @@ async function applyCorrection(value: string) {
       try {
         await browser.runtime.sendMessage({
           type: "fetch",
-          url: `https://api.autodarts.io/gs/v0/matches/${matchId}/corrections`,
+          url: `https://api.autodarts.com/gs/v0/matches/${matchId}/corrections`,
           options: {
             method: "POST",
             credentials: "include",
@@ -864,7 +864,7 @@ async function applyCorrection(value: string) {
           try {
             await browser.runtime.sendMessage({
               type: "fetch",
-              url: `https://api.autodarts.io/gs/v0/matches/${matchId}/corrections`,
+              url: `https://api.autodarts.com/gs/v0/matches/${matchId}/corrections`,
               options: {
                 method: "POST",
                 credentials: "include",
@@ -895,7 +895,7 @@ async function applyCorrection(value: string) {
 
                 await browser.runtime.sendMessage({
                   type: "fetch",
-                  url: `https://api.autodarts.io/gs/v0/matches/${matchId}/throws`,
+                  url: `https://api.autodarts.com/gs/v0/matches/${matchId}/throws`,
                   options: {
                     method: "PATCH",
                     credentials: "include",

--- a/entrypoints/match.content/StreamingMode.vue
+++ b/entrypoints/match.content/StreamingMode.vue
@@ -266,7 +266,7 @@ const game = reactive<{
   footer: string;
 }>({
   title: "",
-  footer: "Game provided by Autodarts.io",
+  footer: "Game provided by Autodarts.com",
 });
 
 const config: Ref<IConfig | null> = ref(null);

--- a/entrypoints/match.content/index.ts
+++ b/entrypoints/match.content/index.ts
@@ -51,7 +51,7 @@ const tools = {
 };
 
 export default defineContentScript({
-  matches: [ "*://play.autodarts.io/*" ],
+  matches: [ "*://play.autodarts.io/*", "*://play.autodarts.com/*" ],
   cssInjectionMode: "ui",
   async main(ctx: any) {
     AutodartsToolsUrlStatus.watch(async (url: string) => {
@@ -67,7 +67,7 @@ export default defineContentScript({
             console.log("Autodarts Tools: Fetching match data with cookie authentication...");
 
             if (url.includes("boards")) {
-              const apiUrl = `https://api.autodarts.io/bs/v0/boards/${matchId}`;
+              const apiUrl = `https://api.autodarts.com/bs/v0/boards/${matchId}`;
               const response = await fetchWithAuth(apiUrl);
 
               if (response.ok) {
@@ -77,7 +77,7 @@ export default defineContentScript({
 
             console.log("Autodarts Tools: Match ID:", matchId);
 
-            const apiUrl = `https://api.autodarts.io/gs/v0/matches/${matchId}/state`;
+            const apiUrl = `https://api.autodarts.com/gs/v0/matches/${matchId}/state`;
             const response = await fetchWithAuth(apiUrl);
 
             console.log("Autodarts Tools: Response status:", response.status);
@@ -292,7 +292,7 @@ function startActiveMatchObserver(ctx) {
       let matchId = url.match(/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/)?.[0];
 
       if (url.includes("boards")) {
-        const apiUrl = `https://api.autodarts.io/bs/v0/boards/${matchId}`;
+        const apiUrl = `https://api.autodarts.com/bs/v0/boards/${matchId}`;
         const response = await fetchWithAuth(apiUrl);
 
         if (response.ok) {

--- a/entrypoints/websocket-monitor.content.ts
+++ b/entrypoints/websocket-monitor.content.ts
@@ -4,7 +4,7 @@
 import { processWebSocketMessage } from "@/utils/websocket-helpers";
 
 export default defineContentScript({
-  matches: [ "*://play.autodarts.io/*" ],
+  matches: [ "*://play.autodarts.io/*", "*://play.autodarts.com/*" ],
   runAt: "document_start",
   async main(ctx) {
     console.log("Injecting WebSocket capture script...");

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "autodarts-tools",
-  "description": "Autodarts Tools enhances the gaming experience on autodarts.io",
+  "description": "Autodarts Tools enhances the gaming experience on autodarts.com",
   "version": "2.3.0",
   "type": "module",
   "author": {

--- a/utils/websocket-helpers.ts
+++ b/utils/websocket-helpers.ts
@@ -294,7 +294,7 @@ export async function processWebSocketMessage(channel: string, data: ILobbies | 
       break; // Temp disabled because it's not working as expected since last update
       data = data as any;
       const boardImages = await AutodartsToolsBoardImages.getValue();
-      const imageUrl = `https://boards.ws.autodarts.io${(data as any).url as string}`;
+      const imageUrl = `https://boards.ws.autodarts.com${(data as any).url as string}`;
 
       // Check for duplicates before adding
       if (!boardImages.images.includes(imageUrl)) {

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
   //   startUrls: [ "https://play.autodarts.io/" ],
   // },
   webExt: {
-    startUrls: [ "https://play.autodarts.io/" ],
+    startUrls: [ "https://play.autodarts.com/", "https://play.autodarts.io/" ],
   },
   modules: [ "@wxt-dev/webextension-polyfill" ],
   imports: {
@@ -24,8 +24,14 @@ export default defineConfig({
   },
   manifest: {
     host_permissions: [
+      "*://play.autodarts.com/*",
       "*://play.autodarts.io/*",
+      "*://api.autodarts.com/*",
       "*://api.autodarts.io/*",
+      "*://login.autodarts.com/*",
+      "*://login.autodarts.io/*",
+      "*://boards.ws.autodarts.com/*",
+      "*://boards.ws.autodarts.io/*",
       "*://darts-downloads.peschi.org/*",
       "*://autodarts.x10.mx/*",
       "*://adt-socket.tobias-thiele.de/*",
@@ -41,7 +47,7 @@ export default defineConfig({
       persistent: false,
     },
     name: "Tools for Autodarts",
-    description: "Tools for Autodarts enhances the gaming experience on autodarts.io",
+    description: "Tools for Autodarts enhances the gaming experience on autodarts.com",
     // content_scripts: [
     //   {
     //     matches: [ "*://play.autodarts.io/*" ],
@@ -55,11 +61,11 @@ export default defineConfig({
     web_accessible_resources: [
       {
         resources: [ "images/*" ],
-        matches: [ "*://play.autodarts.io/*" ],
+        matches: [ "*://play.autodarts.io/*", "*://play.autodarts.com/*" ],
       },
       {
         resources: [ "websocket-capture.js", "auth-cookie.js" ],
-        matches: [ "*://play.autodarts.io/*" ],
+        matches: [ "*://play.autodarts.io/*", "*://play.autodarts.com/*" ],
       },
     ],
   },


### PR DESCRIPTION
AI Summary Slop: 
Following the platform domain change from `autodarts.io` to `autodarts.com`, this PR updates content script match patterns, manifest permissions, authentication token capture, and API fetch endpoints across the extension to support `autodarts.com`.

Backward compatibility for `autodarts.io` has been preserved across host permissions and content script matches so the extension continues functioning seamlessly during the domain transition period.


Actual real world test:
Verified output in '.output/chrome-mv3' - loaded unpacked extension in Chrome and verified the extension behaved as expected - seemed to work fine for the usual features I use.
