### PR TITLE
Feature/keyboard shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,11 @@ Tools for Autodarts is a browser extension that enhances your gaming experience 
   - Numpad keyboard shortcuts for fast corrections
   - Color-coded buttons matching dart board segments
   - Keyboard shortcuts for accessing throws (/, *, -) and making corrections
+- **Keyboard Shortcuts**: Trigger match buttons with configurable keys
+  - Next Leg / Next Set (default: `n`)
+  - Reset board detection (default: `r`)
+  - Referee (default: `c`)
+  - Shortcuts are ignored while typing in input fields
 - **Instant Replay**: Records webcam footage and automatically shows replays of winning throws
 - **Gotcha Helper**: Shows how many points the other players are ahead in Gotcha game variant
   - Displays dart throws needed to catch up

--- a/components/PageConfig.vue
+++ b/components/PageConfig.vue
@@ -223,6 +223,7 @@ import EnhancedScoringDisplay from "./Settings/EnhancedScoringDisplay.vue";
 import InstantReplay from "./Settings/InstantReplay.vue";
 import Gotcha from "./Settings/Gotcha.vue";
 import CheckoutGuide from "./Settings/CheckoutGuide.vue";
+import KeyboardShortcuts from "./Settings/KeyboardShortcuts.vue";
 
 import packageConfig from "../package.json";
 
@@ -277,8 +278,9 @@ const featureGroups = [
       { id: "instant-replay", title: "Instant Replay Settings", component: InstantReplay, hasSettings: true },
       { id: "gotcha", title: "Gotcha Settings", component: Gotcha, hasSettings: false },
       { id: "checkout-guide", title: "Checkout Guide Settings", component: CheckoutGuide, hasSettings: false },
+      { id: "keyboard-shortcuts", title: "Keyboard Shortcuts Settings", component: KeyboardShortcuts, hasSettings: true },
     ],
-    settingIds: [ "colors", "next-player-on-takeout-stuck", "automatic-next-leg", "streaming-mode", "larger-legs-sets", "larger-player-names", "larger-player-match-data", "automatic-fullscreen", "zoom", "quick-correction", "instant-replay" ],
+    settingIds: [ "colors", "next-player-on-takeout-stuck", "automatic-next-leg", "streaming-mode", "larger-legs-sets", "larger-player-names", "larger-player-match-data", "automatic-fullscreen", "zoom", "quick-correction", "instant-replay", "keyboard-shortcuts" ],
   },
   // Boards (Tab 2)
   {

--- a/components/Settings/KeyboardShortcuts.vue
+++ b/components/Settings/KeyboardShortcuts.vue
@@ -1,0 +1,124 @@
+<template>
+  <template v-if="!$attrs['data-feature-index']">
+    <!-- Settings Panel -->
+    <div
+      v-if="config"
+      class="adt-container min-h-56"
+    >
+      <div class="relative z-10 flex h-full flex-col justify-between">
+        <div>
+          <h3 class="mb-1 font-bold uppercase">
+            Settings - Keyboard Shortcuts
+          </h3>
+          <div class="space-y-3 text-white/70">
+            <p>Assign a key to click the match buttons. Press the key during a match to trigger the action. Shortcuts are ignored while typing in an input field.</p>
+
+            <div class="mt-4 space-y-4">
+              <div class="grid grid-cols-[5rem_auto] items-center gap-4">
+                <AppInput
+                  @update:model-value="setKey('nextLeg', $event)"
+                  :model-value="config.shortcuts.nextLeg"
+                  placeholder="n"
+                  size="sm"
+                  input-class="w-full"
+                />
+                <p>Next Leg / Next Set</p>
+              </div>
+              <div class="grid grid-cols-[5rem_auto] items-center gap-4">
+                <AppInput
+                  @update:model-value="setKey('resetBoard', $event)"
+                  :model-value="config.shortcuts.resetBoard"
+                  placeholder="r"
+                  size="sm"
+                  input-class="w-full"
+                />
+                <p>Reset board detection</p>
+              </div>
+              <div class="grid grid-cols-[5rem_auto] items-center gap-4">
+                <AppInput
+                  @update:model-value="setKey('referee', $event)"
+                  :model-value="config.shortcuts.referee"
+                  placeholder="c"
+                  size="sm"
+                  input-class="w-full"
+                />
+                <p>Referee</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </template>
+
+  <template v-else>
+    <!-- Feature Card -->
+    <div
+      v-if="config"
+      class="adt-container h-56 transition-transform hover:-translate-y-0.5"
+    >
+      <div class="relative z-10 flex h-full flex-col justify-between">
+        <div>
+          <h3 class="mb-1 flex items-center font-bold uppercase">
+            Keyboard Shortcuts
+            <span class="icon-[material-symbols--settings-alert-outline-rounded] ml-2 size-5" />
+          </h3>
+
+          <p class="w-2/3 text-white/70">
+            Adds keyboard shortcuts for Next Leg ({{ config?.shortcuts?.nextLeg || 'n' }}), Reset detection ({{ config?.shortcuts?.resetBoard || 'r' }}) and Referee ({{ config?.shortcuts?.referee || 'c' }}).
+          </p>
+        </div>
+        <div class="flex">
+          <div @click="$emit('toggle', 'keyboard-shortcuts')" class="absolute inset-y-0 left-12 right-0 cursor-pointer" />
+          <AppToggle
+            @update:model-value="toggleFeature"
+            v-model="config.shortcuts.enabled"
+          />
+        </div>
+      </div>
+    </div>
+  </template>
+</template>
+
+<script setup lang="ts">
+import AppToggle from "../AppToggle.vue";
+import AppInput from "../AppInput.vue";
+
+import { AutodartsToolsConfig, type IConfig, defaultConfig } from "@/utils/storage";
+
+const emit = defineEmits([ "toggle", "settingChange" ]);
+const config = ref<IConfig>();
+
+async function toggleFeature() {
+  if (!config.value) return;
+
+  // Toggle the feature
+  const wasEnabled = config.value.shortcuts.enabled;
+  config.value.shortcuts.enabled = !wasEnabled;
+
+  // If we're enabling the feature, open settings
+  if (!wasEnabled) {
+    await nextTick();
+    emit("toggle", "keyboard-shortcuts");
+  }
+}
+
+function setKey(action: "nextLeg" | "resetBoard" | "referee", value: string) {
+  if (!config.value) return;
+  // Keep only the last typed character so the field always holds a single key
+  config.value.shortcuts[action] = value.trim().slice(-1).toLowerCase();
+}
+
+onMounted(async () => {
+  config.value = await AutodartsToolsConfig.getValue();
+  if (!config.value?.shortcuts) config.value.shortcuts = defaultConfig.shortcuts;
+});
+
+watch(config, async (_, oldValue) => {
+  if (!oldValue) return;
+
+  await AutodartsToolsConfig.setValue(toRaw(config.value!));
+  emit("settingChange");
+  console.log("Keyboard Shortcuts setting changed");
+}, { deep: true });
+</script>

--- a/entrypoints/content/migration-config.ts
+++ b/entrypoints/content/migration-config.ts
@@ -192,6 +192,15 @@ async function migrateConfig(currentConfigVersion: number) {
           };
         }
         break;
+      case 22:
+        // Migration from version 22 to version 23
+        config.version = 23;
+        if (!config.shortcuts) {
+          config.shortcuts = {
+            ...defaultConfig.shortcuts,
+          };
+        }
+        break;
     }
 
     await AutodartsToolsConfig.setValue(config);

--- a/entrypoints/match.content/index.ts
+++ b/entrypoints/match.content/index.ts
@@ -24,6 +24,7 @@ import Gotcha from "./Gotcha.vue";
 import CheckoutGuide from "./CheckoutGuide.vue";
 import { discordStream, discordStreamOnRemove } from "./discord-stream";
 import { enhancedScoringDisplay, enhancedScoringDisplayOnRemove } from "./enhanced-scoring-display";
+import { keyboardShortcuts, keyboardShortcutsOnRemove } from "./keyboard-shortcuts";
 
 import { waitForElement, waitForElementWithTextContent } from "@/utils";
 import {
@@ -212,6 +213,10 @@ async function initMatch(ctx, url: string, matchId?: string) {
     await initScript(enhancedScoringDisplay, url).catch(console.error);
   }
 
+  if (config.shortcuts?.enabled) {
+    await initScript(keyboardShortcuts, url).catch(console.error);
+  }
+
   // ****************************************************************
 
   if (config.animations.enabled) {
@@ -263,6 +268,7 @@ function clearMatch(fromBullOff: boolean = false) {
   discordStreamOnRemove();
   automaticNextLegOnRemove();
   enhancedScoringDisplayOnRemove();
+  keyboardShortcutsOnRemove();
   matchInitialized = false;
 }
 

--- a/entrypoints/match.content/keyboard-shortcuts.ts
+++ b/entrypoints/match.content/keyboard-shortcuts.ts
@@ -7,7 +7,8 @@ let keydownHandler: ((event: KeyboardEvent) => void) | undefined;
 const buttonLabels: Record<string, string[]> = {
   nextLeg: [ "next leg", "nächstes leg", "volgende leg", "next set", "nächster satz", "volgende set" ],
   resetBoard: [ "reset", "zurücksetzen" ],
-  referee: [ "referee", "schiedsrichter", "scheidsrechter" ],
+  // The referee button is identified by its aria-label "Call referee"
+  referee: [ "call referee", "referee", "schiedsrichter", "scheidsrechter" ],
 };
 
 function findButtonWithText(labels: string[]): HTMLElement | undefined {

--- a/entrypoints/match.content/keyboard-shortcuts.ts
+++ b/entrypoints/match.content/keyboard-shortcuts.ts
@@ -1,0 +1,63 @@
+import type { IConfig } from "@/utils/storage";
+
+import { AutodartsToolsConfig } from "@/utils/storage";
+
+let keydownHandler: ((event: KeyboardEvent) => void) | undefined;
+
+const buttonLabels: Record<string, string[]> = {
+  nextLeg: [ "next leg", "nächstes leg", "volgende leg", "next set", "nächster satz", "volgende set" ],
+  resetBoard: [ "reset", "zurücksetzen" ],
+  referee: [ "referee", "schiedsrichter", "scheidsrechter" ],
+};
+
+function findButtonWithText(labels: string[]): HTMLElement | undefined {
+  const buttons = document.querySelectorAll("button");
+  for (const button of buttons) {
+    const text = button.textContent?.trim().toLowerCase() ?? "";
+    const ariaLabel = button.getAttribute("aria-label")?.trim().toLowerCase() ?? "";
+    if (labels.some(label => text.includes(label) || ariaLabel.includes(label))) {
+      return button as HTMLElement;
+    }
+  }
+  return undefined;
+}
+
+export async function keyboardShortcuts() {
+  const config: IConfig = await AutodartsToolsConfig.getValue();
+
+  keydownHandler = (event: KeyboardEvent) => {
+    if (event.ctrlKey || event.metaKey || event.altKey) return;
+
+    // Ignore keystrokes while typing in inputs or editable elements
+    const target = event.target as HTMLElement | null;
+    if (target && (target.tagName === "INPUT" || target.tagName === "TEXTAREA" || target.tagName === "SELECT" || target.isContentEditable)) return;
+
+    const key = event.key.toLowerCase();
+    const actions: [string, string[]][] = [
+      [ config.shortcuts.nextLeg, buttonLabels.nextLeg ],
+      [ config.shortcuts.resetBoard, buttonLabels.resetBoard ],
+      [ config.shortcuts.referee, buttonLabels.referee ],
+    ];
+
+    for (const [ shortcutKey, labels ] of actions) {
+      if (shortcutKey && key === shortcutKey.toLowerCase()) {
+        const button = findButtonWithText(labels);
+        if (button) {
+          event.preventDefault();
+          button.click();
+        }
+        return;
+      }
+    }
+  };
+
+  window.addEventListener("keydown", keydownHandler);
+  console.log("Autodarts Tools: Keyboard Shortcuts initialized");
+}
+
+export function keyboardShortcutsOnRemove() {
+  if (keydownHandler) {
+    window.removeEventListener("keydown", keydownHandler);
+    keydownHandler = undefined;
+  }
+}

--- a/utils/storage.ts
+++ b/utils/storage.ts
@@ -161,6 +161,12 @@ export interface IConfig {
   checkoutGuide: {
     enabled: boolean;
   };
+  shortcuts: {
+    enabled: boolean;
+    nextLeg: string;
+    resetBoard: string;
+    referee: string;
+  };
 }
 
 export interface ISoundTTS {
@@ -343,7 +349,7 @@ export interface IWled {
 export type TBoardStatus = BoardStatus | undefined;
 
 export const defaultConfig: IConfig = {
-  version: 22,
+  version: 23,
   discord: {
     enabled: false,
     manually: false,
@@ -720,6 +726,12 @@ export const defaultConfig: IConfig = {
   },
   checkoutGuide: {
     enabled: false,
+  },
+  shortcuts: {
+    enabled: false,
+    nextLeg: "n",
+    resetBoard: "r",
+    referee: "c",
   },
 };
 


### PR DESCRIPTION
## What

Adds a new **Keyboard Shortcuts** feature (off by default, Matches tab) that lets you trigger match-page buttons with configurable keys:

- **Next Leg / Next Set** — default `n`
- **Reset board detection** — default `r`
- **Referee** — default `c` (matches the button's "Call referee" aria-label)

Keys are configurable in the feature's settings panel. Shortcuts are ignored while typing in inputs/textareas/editable elements or when Ctrl/Alt/Cmd is held, so they never fire accidentally.

## How

- New `entrypoints/match.content/keyboard-shortcuts.ts`: a `keydown` listener that locates the target button by visible text or aria-label (EN/DE/NL labels, same approach as `automatic-next-leg.ts` and `Takeout.vue`) and clicks it
- New `components/Settings/KeyboardShortcuts.vue` settings component (feature card + key-binding panel), registered in `PageConfig.vue`
- `shortcuts` section added to `IConfig`; config version bumped to 23 with a migration adding the defaults for existing users
- README documents the feature under Gameplay Features

## Testing

- `yarn compile` passes (only the pre-existing baseline errors remain)
- Manually verified against the match page button labels used elsewhere in the codebase; referee button confirmed via its "Call referee" aria-label