### PR TITLE
Add player-specific and checkout-specific animation triggers

### DIFF
--- a/README.md
+++ b/README.md
@@ -590,6 +590,45 @@ Animations can be triggered by various game events using these tags:
   - `outside`: When a dart lands outside the scoring area
   - `busted`: When a player busts (scores more than needed)
   - `gameshot`: When a player wins the game or leg
+  - `matchshot`: When a player wins the complete match
+
+#### Player-Specific Animation Triggers
+
+Every supported in-match Animation trigger can optionally target a player.
+
+- **Stable player slot**: append `_player1`, `_player2`, etc.
+- **Player name**: append `_[player name]`
+- Player names are case-insensitive.
+- Spaces in names can be kept or replaced with underscores.
+
+Examples:
+
+```text
+100_player1
+140_player2
+180_playername
+bull_player1
+outside_player2
+busted_playername
+gameshot_player1
+gameshot_playername
+matchshot_player2
+matchshot_playername
+100-140_player1
+t20_t20_t20_playername
+```
+
+Specificity:
+
+```text
+<trigger>_<player name>
+→ <trigger>_playerN
+→ <trigger>
+```
+
+For a complete match win, the `matchshot` chain is tried first. If no matching
+matchshot animation exists, Animations fall back to the corresponding
+`gameshot` chain.
 
 #### Combination Tags
 You can also use combination tags to trigger animations based on specific dart throw combinations. Format: `[first dart]_[second dart]_[third dart]`

--- a/README.md
+++ b/README.md
@@ -591,6 +591,8 @@ Animations can be triggered by various game events using these tags:
   - `busted`: When a player busts (scores more than needed)
   - `gameshot`: When a player wins the game or leg
   - `matchshot`: When a player wins the complete match
+  - Winner triggers can optionally include the winning dart (for example `gameshot_d10` or `matchshot_bull`)
+  - Winner triggers can also include the complete winning visit (for example `gameshot_s25_bull` or `matchshot_t20_t15_d20`)
 
 #### Player-Specific Animation Triggers
 
@@ -612,8 +614,16 @@ outside_player2
 busted_playername
 gameshot_player1
 gameshot_playername
+gameshot_player1_d10
+gameshot_playername_d10
+gameshot_player1_s25_bull
+gameshot_playername_s25_bull
 matchshot_player2
 matchshot_playername
+matchshot_player2_d1
+matchshot_playername_d1
+matchshot_player2_t20_t15_d20
+matchshot_playername_t20_t15_d20
 100-140_player1
 t20_t20_t20_playername
 ```
@@ -626,9 +636,51 @@ Specificity:
 → <trigger>
 ```
 
-For a complete match win, the `matchshot` chain is tried first. If no matching
-matchshot animation exists, Animations fall back to the corresponding
-`gameshot` chain.
+Winner animations can additionally target the winning dart or the complete
+winning visit. Put the checkout after the optional player suffix.
+
+Examples:
+
+```text
+gameshot_d10
+gameshot_player1_d10
+gameshot_playername_d10
+
+gameshot_s25_bull
+gameshot_player1_s25_bull
+gameshot_playername_s25_bull
+
+matchshot_d1
+matchshot_player2_d1
+matchshot_playername_d1
+
+matchshot_t20_t15_d20
+matchshot_player2_t20_t15_d20
+matchshot_playername_t20_t15_d20
+```
+
+Use the normal dart names for the checkout: `s1`-`s20`, `s25`,
+`d1`-`d20`, `t1`-`t20`, and `bull` for the bullseye. For example,
+a 75 checkout via outer bull followed by bullseye is `s25_bull`, not
+`s25_d25`.
+
+Within each winner family, the most specific enabled trigger wins:
+
+```text
+<gameshot|matchshot>_<player name>_<complete winning visit>
+→ <gameshot|matchshot>_playerN_<complete winning visit>
+→ <gameshot|matchshot>_<complete winning visit>
+→ <gameshot|matchshot>_<player name>_<winning dart>
+→ <gameshot|matchshot>_playerN_<winning dart>
+→ <gameshot|matchshot>_<winning dart>
+→ <gameshot|matchshot>_<player name>
+→ <gameshot|matchshot>_playerN
+→ <gameshot|matchshot>
+```
+
+For a complete match win, the entire `matchshot` chain is tried first. If no
+matching matchshot animation exists, Animations fall back to the corresponding
+`gameshot` chain. Only one winner animation is selected.
 
 #### Combination Tags
 You can also use combination tags to trigger animations based on specific dart throw combinations. Format: `[first dart]_[second dart]_[third dart]`

--- a/README.md
+++ b/README.md
@@ -682,6 +682,21 @@ For a complete match win, the entire `matchshot` chain is tried first. If no
 matching matchshot animation exists, Animations fall back to the corresponding
 `gameshot` chain. Only one winner animation is selected.
 
+#### Board Filtering
+
+Animations can optionally be restricted to one or more Autodarts board IDs.
+Leave the Board IDs field empty to keep the existing behavior and play
+animations for every board.
+
+When one or more board IDs are configured, an animation is only allowed when
+the player responsible for the throw, gameshot or matchshot is using one of
+those boards. This is especially useful for online matches, where a remote
+opponent should not trigger your local celebration GIFs.
+
+Enter one board ID per line. Board IDs are matched case-insensitively. You can
+find a board ID in Autodarts, for example in the board page URL
+(`/boards/<board-id>`).
+
 #### Combination Tags
 You can also use combination tags to trigger animations based on specific dart throw combinations. Format: `[first dart]_[second dart]_[third dart]`
 

--- a/components/Settings/Animations.vue
+++ b/components/Settings/Animations.vue
@@ -26,6 +26,29 @@
           <div class="space-y-3 text-white/70">
             <p>Configure the animations for the game. Click the plus button to add a new animation.</p>
 
+            <!-- Board Filtering -->
+            <div class="mt-4 space-y-2">
+              <div class="grid grid-cols-[auto_1fr] gap-4">
+                <p>
+                  Board IDs:<br>
+                  <span class="text-xs text-white/60">(optional, one per line)</span>
+                </p>
+                <AppTextarea
+                  id="animation-boards"
+                  v-model="animationBoardIds"
+                  :placeholder="boardIdsPlaceholder"
+                  monospace
+                  :rows="3"
+                  :autosize="false"
+                />
+              </div>
+              <p class="text-xs text-white/60">
+                Leave empty to play animations for every board. When board IDs are configured,
+                animations only play for throws and wins by players on those boards. This is useful
+                in online matches so an opponent's board does not trigger your local GIFs.
+              </p>
+            </div>
+
             <!-- Animation Settings -->
             <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
               <div>
@@ -468,6 +491,20 @@ const lowercaseText = computed({
   get: () => newAnimation.value.text,
   set: (val: string) => {
     newAnimation.value.text = val.toLowerCase();
+  },
+});
+
+const boardIdsPlaceholder = "6a501a61-53a5-468a-a56a-17134ace3099\n6128583a-66d8-46a7-87be-97f045ce7456\n...";
+
+const animationBoardIds = computed({
+  get: () => (config.value?.animations.boardIds ?? []).join("\n"),
+  set: (val: string) => {
+    if (!config.value) return;
+
+    config.value.animations.boardIds = val
+      .split(/\r?\n/)
+      .map(id => id.trim().toLowerCase())
+      .filter(Boolean);
   },
 });
 

--- a/entrypoints/match.content/Animations.vue
+++ b/entrypoints/match.content/Animations.vue
@@ -26,7 +26,7 @@
 
 <script setup lang="ts">
 import type { IGameData } from "@/utils/game-data-storage";
-import type { IThrow } from "@/utils/websocket-helpers";
+import type { IPlayer, IThrow } from "@/utils/websocket-helpers";
 
 import { AutodartsToolsGameData } from "@/utils/game-data-storage";
 import { getAnimationFromOPFS, isOPFSAvailable, triggerPatterns } from "@/utils/helpers";
@@ -134,29 +134,42 @@ async function processGameData(gameData: IGameData): Promise<void> {
   if (!gameData.match || gameData.match.activated !== undefined || !gameData.match.turns?.length) return;
   if (gameData.match.variant === "Bull-off") return;
 
-  const turn = gameData.match.turns[0];
+  const match = gameData.match;
+  const turn = match.turns[0];
   const currentThrow = turn.throws[turn.throws.length - 1];
   if (!currentThrow) return;
 
   const throwName: string = dartName(currentThrow); // s1
   const isLastThrow: boolean = turn.throws.length >= 3;
-  const winner: boolean = gameData.match.gameWinner >= 0;
+  const winner: boolean = match.gameWinner >= 0;
+  const winnerMatch: boolean = match.winner >= 0;
   const busted: boolean = turn.busted;
   const points: number = turn.points;
   const miss: boolean = throwName.startsWith("m");
   const combination: string = turn.throws.map(dartName).join("_");
 
+  const currentPlayer = findTurnPlayer(match.players, turn.playerId, match.player);
+  const gameWinnerPlayer = findGameWinnerPlayer(match.players, match.gameWinner) ?? currentPlayer;
+  const matchWinnerPlayer = findMatchWinnerPlayer(match.players, match.winner) ?? gameWinnerPlayer;
+
   // `25` is what setups have always used for the single bull, so it goes on
   // meaning that; `s25` takes over only when an animation is waiting on it.
-  play(throwName === "s25" && !hasTrigger("s25") ? "25" : throwName);
-  if (winner) play("gameshot");
-  if (busted) play("busted");
-  if (isLastThrow && !busted) {
-    play(points.toString());
-    await new Promise(resolve => setTimeout(resolve, COMBINATION_GAP_MS));
-    play(combination);
+  play(
+    throwName === "s25" && !hasTriggerForPlayer("s25", currentPlayer) ? "25" : throwName,
+    currentPlayer,
+  );
+
+  if (winner) {
+    playWinner(winnerMatch, winnerMatch ? matchWinnerPlayer : gameWinnerPlayer);
   }
-  if (miss) play("outside");
+
+  if (busted) play("busted", currentPlayer);
+  if (isLastThrow && !busted) {
+    play(points.toString(), currentPlayer);
+    await new Promise(resolve => setTimeout(resolve, COMBINATION_GAP_MS));
+    play(combination, currentPlayer);
+  }
+  if (miss) play("outside", currentPlayer);
 }
 
 /**
@@ -174,47 +187,158 @@ function dartName(dart: IThrow): string {
   return name === "25" && dart.segment.bed === "Single" ? "s25" : name;
 }
 
-/** Whether an enabled animation is waiting on this exact trigger. */
-function hasTrigger(trigger: string): boolean {
-  return Boolean(config.value?.animations?.data?.some(
-    animation => animation.enabled && Array.isArray(animation.triggers) && animation.triggers.includes(trigger),
-  ));
+function findTurnPlayer(
+  players: IPlayer[] | undefined,
+  playerId: string,
+  fallbackPosition: number,
+): IPlayer | undefined {
+  if (!players) return undefined;
+
+  return players.find(player => player.id === playerId || player.userId === playerId)
+    ?? players[fallbackPosition];
 }
 
-/** Pick an animation for a trigger, at random when several match. */
-async function resolveAnimation(trigger: string): Promise<string | null> {
+/**
+ * `gameWinner` indexes the current leg's reordered `match.players` array.
+ * The stable slot is carried by the resolved player's `index`.
+ */
+function findGameWinnerPlayer(
+  players: IPlayer[] | undefined,
+  gameWinner: number,
+): IPlayer | undefined {
+  if (!players || gameWinner < 0) return undefined;
+  return players[gameWinner];
+}
+
+/** `winner` is the stable match seat exposed by `player.index`. */
+function findMatchWinnerPlayer(
+  players: IPlayer[] | undefined,
+  winner: number,
+): IPlayer | undefined {
+  if (!players || winner < 0) return undefined;
+  return players.find(player => player.index === winner);
+}
+
+interface TriggerScope {
+  suffixes: string[];
+  displaySuffix: string;
+}
+
+function triggerScopes(player: IPlayer | undefined): TriggerScope[] {
+  const scopes: TriggerScope[] = [];
+
+  if (player?.name) {
+    const nameWithSpaces = player.name.trim().toLowerCase();
+    const nameWithUnderscores = nameWithSpaces.replace(/\s+/g, "_");
+    const suffixes = [ ...new Set([ nameWithUnderscores, nameWithSpaces ].filter(Boolean)) ];
+
+    if (suffixes.length) {
+      scopes.push({ suffixes, displaySuffix: nameWithUnderscores });
+    }
+  }
+
+  if (player && Number.isInteger(player.index) && player.index >= 0) {
+    const slot = `player${player.index + 1}`;
+    scopes.push({ suffixes: [ slot ], displaySuffix: slot });
+  }
+
+  scopes.push({ suffixes: [ "" ], displaySuffix: "" });
+  return scopes;
+}
+
+function baseTriggerMatches(configuredTrigger: string, eventTrigger: string): boolean {
+  if (configuredTrigger === eventTrigger) return true;
+
+  const asNumber = Number(eventTrigger);
+  if (Number.isNaN(asNumber)) return false;
+
+  const range = configuredTrigger.match(triggerPatterns.ranges);
+  return range
+    ? asNumber >= Number(range[1]) && asNumber <= Number(range[2])
+    : false;
+}
+
+function matchesScope(animation: IAnimation, eventTrigger: string, scope: TriggerScope): boolean {
+  if (!Array.isArray(animation.triggers)) return false;
+
+  return animation.triggers.some((rawTrigger: string) => {
+    const configuredTrigger = rawTrigger.trim().toLowerCase();
+
+    for (const suffix of scope.suffixes) {
+      if (!suffix) {
+        if (baseTriggerMatches(configuredTrigger, eventTrigger)) return true;
+        continue;
+      }
+
+      const ending = `_${suffix}`;
+      if (!configuredTrigger.endsWith(ending)) continue;
+
+      const baseTrigger = configuredTrigger.slice(0, -ending.length);
+      if (baseTriggerMatches(baseTrigger, eventTrigger)) return true;
+    }
+
+    return false;
+  });
+}
+
+function matchingAnimations(
+  trigger: string,
+  player: IPlayer | undefined,
+): { animations: IAnimation[]; resolvedTrigger: string } | null {
   const animations = config.value?.animations?.data;
   if (!animations?.length) return null;
 
-  const matched = animations.filter(animation => animation.enabled && matchesTrigger(animation, trigger));
-  if (!matched.length) return null;
+  for (const scope of triggerScopes(player)) {
+    const matched = animations.filter(
+      animation => animation.enabled && matchesScope(animation, trigger, scope),
+    );
 
-  const picked = matched[Math.floor(Math.random() * matched.length)];
+    if (matched.length) {
+      return {
+        animations: matched,
+        resolvedTrigger: scope.displaySuffix ? `${trigger}_${scope.displaySuffix}` : trigger,
+      };
+    }
+  }
+
+  return null;
+}
+
+function hasTriggerForPlayer(trigger: string, player: IPlayer | undefined): boolean {
+  return matchingAnimations(trigger, player) !== null;
+}
+
+function playWinner(matchWinner: boolean, player: IPlayer | undefined): void {
+  if (matchWinner && hasTriggerForPlayer("matchshot", player)) {
+    void play("matchshot", player);
+    return;
+  }
+
+  void play("gameshot", player);
+}
+
+/** Pick an animation for a trigger, at random when several match. */
+async function resolveAnimation(
+  trigger: string,
+  player: IPlayer | undefined,
+): Promise<{ url: string; resolvedTrigger: string } | null> {
+  const result = matchingAnimations(trigger, player);
+  if (!result) return null;
+
+  const picked = result.animations[Math.floor(Math.random() * result.animations.length)];
 
   // Uploaded GIFs live in OPFS and are addressed by id; the rest are plain URLs.
   if (picked.animationId && !picked.url) {
     const cached = opfsUrls.get(picked.animationId);
-    if (cached) return cached;
-    return await loadFromOPFS(picked.animationId);
+    if (cached) return { url: cached, resolvedTrigger: result.resolvedTrigger };
+
+    const url = await loadFromOPFS(picked.animationId);
+    return url ? { url, resolvedTrigger: result.resolvedTrigger } : null;
   }
 
-  return picked.url;
-}
-
-function matchesTrigger(animation: IAnimation, trigger: string): boolean {
-  if (!Array.isArray(animation.triggers)) return false;
-
-  // Range triggers ("100-140") only ever apply to a numeric trigger.
-  const asNumber = Number(trigger);
-  if (!Number.isNaN(asNumber)) {
-    const inRange = animation.triggers.some((t: string) => {
-      const range = t.match(triggerPatterns.ranges);
-      return range ? asNumber >= Number(range[1]) && asNumber <= Number(range[2]) : false;
-    });
-    if (inRange) return true;
-  }
-
-  return animation.triggers.includes(trigger);
+  return picked.url
+    ? { url: picked.url, resolvedTrigger: result.resolvedTrigger }
+    : null;
 }
 
 async function loadFromOPFS(animationId: string): Promise<string | null> {
@@ -236,12 +360,13 @@ async function loadFromOPFS(animationId: string): Promise<string | null> {
   return null;
 }
 
-async function play(trigger: string): Promise<void> {
+async function play(trigger: string, player?: IPlayer): Promise<void> {
   try {
-    const url = await resolveAnimation(trigger);
-    if (!url) return;
+    const resolved = await resolveAnimation(trigger, player);
+    if (!resolved) return;
 
-    console.log("Autodarts Tools: Animations - playing", trigger);
+    const { url, resolvedTrigger } = resolved;
+    console.log("Autodarts Tools: Animations - playing", resolvedTrigger);
 
     // The board moves with the window and with the player count, so its
     // position is only worth knowing at the moment it is covered.

--- a/entrypoints/match.content/Animations.vue
+++ b/entrypoints/match.content/Animations.vue
@@ -165,6 +165,7 @@ async function processGameData(gameData: IGameData): Promise<void> {
       winnerMatch ? matchWinnerPlayer : gameWinnerPlayer,
       combination,
       throwName,
+      currentPlayer,
     );
   }
 
@@ -384,6 +385,7 @@ function playWinner(
   player: IPlayer | undefined,
   winningCombination: string,
   winningThrow: string,
+  boardPlayer: IPlayer | undefined,
 ): void {
   const triggerFamilies: Array<"gameshot" | "matchshot"> = matchWinner
     ? [ "matchshot", "gameshot" ]
@@ -398,7 +400,9 @@ function playWinner(
     ).find(hasExactTrigger);
 
     if (resolvedTrigger) {
-      void play(resolvedTrigger);
+      // The trigger is already fully resolved here. Use the player who threw the
+      // winning dart only for board filtering, while keeping exact-trigger playback.
+      void play(resolvedTrigger, undefined, boardPlayer);
       return;
     }
   }
@@ -447,8 +451,35 @@ async function loadFromOPFS(animationId: string): Promise<string | null> {
   return null;
 }
 
-async function play(trigger: string, player?: IPlayer): Promise<void> {
+function isAnimationBoardAllowed(player: IPlayer | undefined): boolean {
+  const boardIds = (config.value?.animations?.boardIds ?? [])
+    .map(id => id.trim().toLowerCase())
+    .filter(Boolean);
+
+  if (!boardIds.length) return true;
+
+  const boardId = player?.boardId?.trim().toLowerCase();
+  return Boolean(boardId && boardIds.includes(boardId));
+}
+
+async function play(
+  trigger: string,
+  player?: IPlayer,
+  boardPlayer?: IPlayer,
+): Promise<void> {
   try {
+    const filterPlayer = boardPlayer ?? player;
+
+    if (!isAnimationBoardAllowed(filterPlayer)) {
+      console.log(
+        "Autodarts Tools: Animations - skipped",
+        trigger,
+        "for board",
+        filterPlayer?.boardId || "unknown",
+      );
+      return;
+    }
+
     const resolved = await resolveAnimation(trigger, player);
     if (!resolved) return;
 

--- a/entrypoints/match.content/Animations.vue
+++ b/entrypoints/match.content/Animations.vue
@@ -160,7 +160,12 @@ async function processGameData(gameData: IGameData): Promise<void> {
   );
 
   if (winner) {
-    playWinner(winnerMatch, winnerMatch ? matchWinnerPlayer : gameWinnerPlayer);
+    playWinner(
+      winnerMatch,
+      winnerMatch ? matchWinnerPlayer : gameWinnerPlayer,
+      combination,
+      throwName,
+    );
   }
 
   if (busted) play("busted", currentPlayer);
@@ -308,13 +313,95 @@ function hasTriggerForPlayer(trigger: string, player: IPlayer | undefined): bool
   return matchingAnimations(trigger, player) !== null;
 }
 
-function playWinner(matchWinner: boolean, player: IPlayer | undefined): void {
-  if (matchWinner && hasTriggerForPlayer("matchshot", player)) {
-    void play("matchshot", player);
-    return;
-  }
+function normalizedPlayerNameSuffixes(player: IPlayer | undefined): string[] {
+  if (!player?.name) return [];
 
-  void play("gameshot", player);
+  const nameWithSpaces = player.name.trim().toLowerCase();
+  const nameWithUnderscores = nameWithSpaces.replace(/\s+/g, "_");
+  return [ ...new Set([ nameWithUnderscores, nameWithSpaces ].filter(Boolean)) ];
+}
+
+function hasExactTrigger(trigger: string): boolean {
+  const animations = config.value?.animations?.data;
+  if (!animations?.length) return false;
+
+  return animations.some(
+    animation => animation.enabled
+      && Array.isArray(animation.triggers)
+      && animation.triggers.some(
+        rawTrigger => rawTrigger.trim().toLowerCase() === trigger,
+      ),
+  );
+}
+
+/**
+ * Winner-trigger priority inside one family:
+ * 1. player name + complete winning visit
+ * 2. stable player slot + complete winning visit
+ * 3. generic complete winning visit
+ * 4. player name + winning dart
+ * 5. stable player slot + winning dart
+ * 6. generic winning dart
+ * 7. player name
+ * 8. stable player slot
+ * 9. generic
+ */
+function winnerTriggerCandidates(
+  baseTrigger: "gameshot" | "matchshot",
+  player: IPlayer | undefined,
+  winningCombination: string,
+  winningThrow: string,
+): string[] {
+  const candidates: string[] = [];
+  const names = normalizedPlayerNameSuffixes(player);
+  const slot = player && Number.isInteger(player.index) && player.index >= 0
+    ? "player" + (player.index + 1)
+    : null;
+
+  const addScope = (eventSuffix?: string): void => {
+    const tail = eventSuffix ? "_" + eventSuffix : "";
+
+    for (const name of names) {
+      candidates.push(baseTrigger + "_" + name + tail);
+    }
+
+    if (slot) {
+      candidates.push(baseTrigger + "_" + slot + tail);
+    }
+
+    candidates.push(baseTrigger + tail);
+  };
+
+  if (winningCombination) addScope(winningCombination);
+  if (winningThrow && winningThrow !== winningCombination) addScope(winningThrow);
+  addScope();
+
+  return [ ...new Set(candidates) ];
+}
+
+function playWinner(
+  matchWinner: boolean,
+  player: IPlayer | undefined,
+  winningCombination: string,
+  winningThrow: string,
+): void {
+  const triggerFamilies: Array<"gameshot" | "matchshot"> = matchWinner
+    ? [ "matchshot", "gameshot" ]
+    : [ "gameshot" ];
+
+  for (const baseTrigger of triggerFamilies) {
+    const resolvedTrigger = winnerTriggerCandidates(
+      baseTrigger,
+      player,
+      winningCombination,
+      winningThrow,
+    ).find(hasExactTrigger);
+
+    if (resolvedTrigger) {
+      void play(resolvedTrigger);
+      return;
+    }
+  }
 }
 
 /** Pick an animation for a trigger, at random when several match. */

--- a/utils/helpers.ts
+++ b/utils/helpers.ts
@@ -978,12 +978,51 @@ export const triggerPatterns = {
   triples: /^t(1[0-9]|20|[1-9])$/,
 
   // Special events
-  specialEvents: /^(bull|outside|busted|gameshot)$/,
+  specialEvents: /^(bull|outside|busted|gameshot|matchshot)$/,
 
   // Combination tags: Format: [first dart]_[second dart]_[third dart]
   // Each dart can be a single, double, triple, or bull
   dartPattern: /^(s(1[0-9]|20|[0-9]|25)|d(1[0-9]|20|[1-9])|t(1[0-9]|20|[1-9])|bull)$/,
 };
+
+/** Whether a trigger is one of the existing supported Animation formats. */
+function isValidAnimationBaseTrigger(trigger: string): boolean {
+  if (
+    triggerPatterns.points.test(trigger)
+    || triggerPatterns.singles.test(trigger)
+    || triggerPatterns.doubles.test(trigger)
+    || triggerPatterns.triples.test(trigger)
+    || triggerPatterns.specialEvents.test(trigger)
+    || triggerPatterns.ranges.test(trigger)
+  ) {
+    return true;
+  }
+
+  const parts = trigger.split("_");
+  return parts.length >= 2
+    && parts.length <= 3
+    && parts.every(part => triggerPatterns.dartPattern.test(part));
+}
+
+/**
+ * A player-specific Animation trigger is an existing valid trigger plus a
+ * non-empty suffix. Search from right to left so underscore-based ranges,
+ * combinations and player names can coexist.
+ */
+function isValidAnimationTrigger(trigger: string): boolean {
+  if (isValidAnimationBaseTrigger(trigger)) return true;
+
+  let splitAt = trigger.lastIndexOf("_");
+  while (splitAt > 0) {
+    const baseTrigger = trigger.slice(0, splitAt);
+    const playerSuffix = trigger.slice(splitAt + 1);
+
+    if (playerSuffix && isValidAnimationBaseTrigger(baseTrigger)) return true;
+    splitAt = trigger.lastIndexOf("_", splitAt - 1);
+  }
+
+  return false;
+}
 
 /**
  * Validates animation triggers according to the supported formats
@@ -1003,47 +1042,11 @@ export function validateAnimationTriggers(triggers: string[]): {
     return { validTriggers: [], invalidTriggers: [] };
   }
 
-  // Combination pattern builder
-  const isValidCombination = (combo: string): boolean => {
-    const parts = combo.split("_");
-
-    // Must have 2 or 3 parts
-    if (parts.length < 2 || parts.length > 3) {
-      return false;
-    }
-
-    // Each part must be a valid dart
-    return parts.every(part => triggerPatterns.dartPattern.test(part));
-  };
-
-  // Process each trigger
   for (const trigger of triggers) {
     const trimmedTrigger = trigger.trim().toLowerCase();
+    if (!trimmedTrigger) continue;
 
-    // Skip empty triggers
-    if (!trimmedTrigger) {
-      continue;
-    }
-
-    // Check if it's a valid combination
-    if (trimmedTrigger.includes("_")) {
-      if (isValidCombination(trimmedTrigger)) {
-        validTriggers.push(trimmedTrigger);
-      } else {
-        invalidTriggers.push(trimmedTrigger);
-      }
-      continue;
-    }
-
-    // Check against all single-dart patterns
-    if (
-      triggerPatterns.points.test(trimmedTrigger)
-      || triggerPatterns.singles.test(trimmedTrigger)
-      || triggerPatterns.doubles.test(trimmedTrigger)
-      || triggerPatterns.triples.test(trimmedTrigger)
-      || triggerPatterns.specialEvents.test(trimmedTrigger)
-      || triggerPatterns.ranges.test(trimmedTrigger)
-    ) {
+    if (isValidAnimationTrigger(trimmedTrigger)) {
       validTriggers.push(trimmedTrigger);
     } else {
       invalidTriggers.push(trimmedTrigger);

--- a/utils/storage.ts
+++ b/utils/storage.ts
@@ -107,6 +107,8 @@ export interface IConfig {
 
   animations: {
     enabled: boolean;
+    /** Optional allowlist. Empty/undefined means animations may play for every board. */
+    boardIds?: string[];
     duration?: number;
     delayStart?: number;
     objectFit?: "cover" | "contain";
@@ -520,6 +522,7 @@ export const defaultConfig: IConfig = {
   },
   animations: {
     enabled: false,
+    boardIds: [],
     duration: 5,
     delayStart: 1,
     objectFit: "cover",


### PR DESCRIPTION
## Deutsch

Dieser PR erweitert das **Animations-System** um:

- player-spezifische Animationen
- personalisierte `gameshot`- und `matchshot`-Animationen
- Trigger für den entscheidenden Winning Dart
- Trigger für den kompletten Winning Visit
- einen optionalen Board-ID-Filter für Online-Matches

Bestehende Animation-Trigger funktionieren weiterhin unverändert.

---

### 1. Player-spezifische Animationen

Bestehende Animation-Trigger können jetzt einem bestimmten Spieler zugeordnet werden.

Dafür gibt es zwei Möglichkeiten:

#### Über den Spielernamen

```text
180_playername
bull_playername
busted_playername
gameshot_playername
matchshot_playername
```

Damit kann beispielsweise jeder Spieler seine eigene 180- oder Gewinnanimation erhalten.

Player-Namen werden case-insensitive behandelt.

Bei Namen mit Leerzeichen funktionieren sowohl Leerzeichen als auch Unterstriche.

Beispiel für den Spielernamen `Player Name`:

```text
180_player name
180_player_name
```

#### Über einen festen Spieler-Slot

```text
180_player1
180_player2
bull_player1
gameshot_player1
matchshot_player2
```

`player1`, `player2`, usw. beziehen sich auf den festen Match-Slot.

Die Zuordnung bleibt auch dann gleich, wenn in einem neuen Leg ein anderer Spieler beginnt.

---

### Unterstützte player-spezifische Trigger

Die Erweiterung funktioniert mit den bestehenden In-Match-Animation-Triggern:

| Funktion | Beispiel |
| --- | --- |
| Punkte | `180_playername` |
| Punktebereich | `100-140_player1` |
| Single | `s20_playername` |
| Double | `d20_player1` |
| Triple | `t20_player2` |
| Outer Bull | `s25_playername` |
| Bullseye | `bull_player1` |
| Outside | `outside_player2` |
| Bust | `busted_playername` |
| Dart-Kombination | `t20_t20_t20_player1` |
| Gameshot | `gameshot_playername` |
| Matchshot | `matchshot_player2` |

Auch bestehende Kombinationen und Ranges können damit personalisiert werden:

```text
100-140_playername
t20_t20_t20_player1
s20_s5_d20_playername
```

---

### 2. Fallback für Player-Trigger

Wenn eine player-spezifische Animation nicht vorhanden ist, wird automatisch auf die nächste passende Variante zurückgefallen.

Reihenfolge:

```text
<trigger>_<player name>
→ <trigger>_playerN
→ <trigger>
```

Beispiel:

```text
140_playername
→ 140_player1
→ 140
```

Existiert also keine persönliche Animation für den Namen, kann zunächst die Slot-Animation verwendet werden und danach die normale generische Animation.

Bestehende Setups funktionieren dadurch weiterhin.

---

### 3. Personalisierte Gameshot- und Matchshot-Animationen

`gameshot` kann jetzt gezielt für einzelne Spieler verwendet werden.

Beispiele:

```text
gameshot_playername
gameshot_player1
```

Damit kann jeder Spieler seine eigene Leg-/Game-Win-Animation erhalten.

Zusätzlich wurde `matchshot` als eigener Animation-Trigger ergänzt:

```text
matchshot
matchshot_playername
matchshot_player2
```

Dadurch können Leg-/Game-Gewinn und kompletter Matchgewinn getrennte Animationen verwenden.

Beispiel:

```text
gameshot_playername
→ persönliche Animation bei einem gewonnenen Leg

matchshot_playername
→ persönliche Animation beim Gewinn des kompletten Matches
```

Bei einem Matchgewinn wird zuerst nach einer passenden `matchshot`-Animation gesucht.

Nur wenn keine passende Matchshot-Animation vorhanden ist, wird auf `gameshot` zurückgefallen.

Dadurch wird nur eine Winner-Animation abgespielt.

---

### 4. Winning Dart

Winner-Animationen können zusätzlich davon abhängig gemacht werden, **mit welchem Dart gewonnen wurde**.

Beispiele:

```text
gameshot_d20
gameshot_d10
matchshot_bull
```

Das bedeutet zum Beispiel:

```text
gameshot_d20
```

wird nur ausgelöst, wenn das Leg tatsächlich auf D20 gewonnen wurde.

Ein normales D20 während des Legs löst diese Animation nicht aus.

Auch personalisiert möglich:

```text
gameshot_playername_d20
gameshot_player1_d20

matchshot_playername_bull
matchshot_player2_d1
```

Beispiel:

```text
gameshot_playername_d20
```

= persönliche Gameshot-Animation für diesen Spieler, aber nur bei einem Finish auf D20.

Damit wird auch der konkrete Gameshot-+-Dart-Anwendungsfall aus #108 abgedeckt.

---

### 5. Kompletter Winning Visit

Zusätzlich zum letzten Dart kann auch der **gesamte Winning Visit** als Trigger verwendet werden.

Beispiel für ein 75er-Finish über Outer Bull + Bullseye:

```text
gameshot_s25_bull
```

Personalisiert:

```text
gameshot_playername_s25_bull
gameshot_player1_s25_bull
```

Beispiel für einen Matchgewinn über T20 + T15 + D20:

```text
matchshot_t20_t15_d20
matchshot_playername_t20_t15_d20
matchshot_player2_t20_t15_d20
```

Verwendet werden die normalen Dart-Namen:

```text
s1-s20
s25
d1-d20
t1-t20
bull
```

Beispiel:

```text
s25_bull
```

bedeutet Outer Bull + Bullseye.

---

### 6. Priorität bei Winner-Animationen

Die spezifischste passende Animation wird zuerst verwendet.

Vereinfacht gilt:

```text
kompletter Winning Visit
→ Winning Dart
→ persönliche Winner-Animation
→ normale Winner-Animation
```

Innerhalb jeder Stufe gilt zusätzlich:

```text
Playername
→ Player-Slot
→ generisch
```

Beispiel für ein persönliches Finish über `s25_bull`:

```text
gameshot_playername_s25_bull
→ gameshot_player1_s25_bull
→ gameshot_s25_bull
→ gameshot_playername_bull
→ gameshot_player1_bull
→ gameshot_bull
→ gameshot_playername
→ gameshot_player1
→ gameshot
```

Für Matchgewinne gilt dieselbe Logik mit `matchshot`.

---

### 7. Optionaler Board-ID-Filter

Der Board-ID-Filter ist vor allem für **Online-Matches** gedacht.

Ohne Filter können auch Würfe oder Siege eines Gegners auf einem fremden Board lokale Animationen auslösen.

Beispiel:

```text
eigene 180
→ eigene Animation soll laufen

180 des Online-Gegners
→ eigene lokale Animation soll nicht laufen
```

Dafür kann in den Animation-Einstellungen die eigene Board-ID eingetragen werden.

```text
Board IDs:
deine-board-id
```

Eine Board-ID pro Zeile:

```text
Board IDs:
board-id-1
board-id-2
```

Die Board-ID findet man beispielsweise in der Autodarts-Board-URL:

```text
/boards/<board-id>
```

#### Feld leer

```text
Board IDs:
[leer]
```

→ Filter deaktiviert  
→ Animationen funktionieren wie bisher für alle Boards

#### Board-ID eingetragen

```text
eigene Board-ID
→ eigene Animationen laufen

anderes Board
→ Animationen werden blockiert
```

Der Filter gilt für normale Trigger genauso wie für:

```text
gameshot
gameshot_playername
gameshot_playername_d20
matchshot
matchshot_player2
matchshot_player2_s25_bull
```

So löst ein Online-Gegner auf einem fremden Board keine lokalen Jubel-GIFs oder persönlichen Winner-Animationen aus.

Zum Deaktivieren einfach alle Board-IDs wieder aus dem Feld entfernen.

---

### 8. Kompatibilität

Bestehende generische Animation-Trigger funktionieren weiterhin unverändert:

```text
180
100-140
s20
d20
t20
bull
outside
busted
t20_t20_t20
gameshot
```

Die neuen Player-, Matchshot-, Winning-Dart- und Winning-Visit-Trigger sind zusätzliche Optionen.

Mehrere Animationen mit demselben ausgewählten Trigger funktionieren weiterhin wie bisher: eine passende Animation wird zufällig ausgewählt.

---

### Tests

Unter anderem erfolgreich getestet:

```text
Playername → Slot → Generic Fallback
stabile player1/player2-Zuordnung bei wechselndem Leg-Starter

180 / bull / outside / busted
Ranges
Dart-Kombinationen

gameshot_playername
matchshot_playername

gameshot_playername_d10
gameshot_player1_d10
gameshot_d10

gameshot_playername_s25_bull
gameshot_player1_s25_bull
gameshot_s25_bull

matchshot_playername_d1
matchshot_playername_s25_bull

Matchshot → Gameshot Fallback
```

Board-Filter ebenfalls live getestet:

```text
Board IDs leer
→ Animationen laufen

eigene Board-ID
→ normale Animation läuft
→ Gameshot läuft
→ Matchshot läuft

falsche/fremde Board-ID
→ normale Animation blockiert
→ Gameshot blockiert
→ Matchshot blockiert
```

`yarn build` läuft erfolgreich.

`yarn compile` zeigt weiterhin nur die bereits in 3.0.7 vorhandenen 17 Fehler in 10 Dateien. Durch diesen PR kommen keine neuen TypeScript-Fehler hinzu.

### Möglicher Follow-up

Die neue Trigger-Auflösung könnte später auch für Sound FX verwendet werden, sodass Animationen und Sounds dieselbe player-, checkout- und finish-spezifische Syntax verwenden können.

Das ist bewusst nicht Bestandteil dieses PRs.

Closes #224  
Closes #169  
Addresses #108

-------------------------------------------------------------------------------------------------------------------------

## English

This PR extends the **Animations system** with:

- player-specific Animations
- personalized `gameshot` and `matchshot` Animations
- winning-dart triggers
- complete winning-visit triggers
- optional Board ID filtering for online matches

Existing Animation triggers continue to work unchanged.

---

### 1. Player-specific Animations

Existing Animation triggers can now target a specific player.

Two methods are supported:

#### Player name

```text
180_playername
bull_playername
busted_playername
gameshot_playername
matchshot_playername
```

This allows every player to have individual 180, Bull, Bust or winner animations.

Player names are case-insensitive.

Names containing spaces can use either spaces or underscores.

Example for `Player Name`:

```text
180_player name
180_player_name
```

#### Stable player slot

```text
180_player1
180_player2
bull_player1
gameshot_player1
matchshot_player2
```

`player1`, `player2`, etc. refer to the stable match seat.

The assignment does not change when another player starts the next leg.

---

### Supported player-specific triggers

| Feature | Example |
| --- | --- |
| Points | `180_playername` |
| Range | `100-140_player1` |
| Single | `s20_playername` |
| Double | `d20_player1` |
| Triple | `t20_player2` |
| Outer Bull | `s25_playername` |
| Bullseye | `bull_player1` |
| Outside | `outside_player2` |
| Bust | `busted_playername` |
| Dart combination | `t20_t20_t20_player1` |
| Gameshot | `gameshot_playername` |
| Matchshot | `matchshot_player2` |

Examples:

```text
100-140_playername
t20_t20_t20_player1
s20_s5_d20_playername
```

---

### 2. Player fallback

Player-specific triggers automatically fall back to the next available level:

```text
<trigger>_<player name>
→ <trigger>_playerN
→ <trigger>
```

Example:

```text
140_playername
→ 140_player1
→ 140
```

This keeps existing generic Animation configurations fully compatible.

---

### 3. Personalized Gameshot and Matchshot Animations

Gameshot Animations can now be personalized per player:

```text
gameshot_playername
gameshot_player1
```

This allows each player to have an individual leg/game-winning animation.

A new `matchshot` Animation trigger is also added:

```text
matchshot
matchshot_playername
matchshot_player2
```

This separates leg/game wins from complete match wins.

Example:

```text
gameshot_playername
→ personal animation for winning a leg

matchshot_playername
→ personal animation for winning the complete match
```

For a complete match win, the `matchshot` chain is checked first.

Only if no matching Matchshot Animation exists does it fall back to `gameshot`.

Only one winner animation is selected.

---

### 4. Winning dart

Winner Animations can also depend on **the dart that actually won the leg or match**.

Examples:

```text
gameshot_d20
gameshot_d10
matchshot_bull
```

For example:

```text
gameshot_d20
```

only triggers when the leg is actually won on D20.

Player-specific versions are also supported:

```text
gameshot_playername_d20
gameshot_player1_d20

matchshot_playername_bull
matchshot_player2_d1
```

Example:

```text
gameshot_playername_d20
```

= a personalized Gameshot Animation for that player, only when winning on D20.

This also covers the concrete Gameshot + dart use case described in #108.

---

### 5. Complete winning visit

The **complete winning visit** can also be used as a trigger.

Example for a 75 checkout via Outer Bull + Bullseye:

```text
gameshot_s25_bull
```

Player-specific:

```text
gameshot_playername_s25_bull
gameshot_player1_s25_bull
```

Example for winning a match via T20 + T15 + D20:

```text
matchshot_t20_t15_d20
matchshot_playername_t20_t15_d20
matchshot_player2_t20_t15_d20
```

Normal dart names are used:

```text
s1-s20
s25
d1-d20
t1-t20
bull
```

Example:

```text
s25_bull
```

means Outer Bull + Bullseye.

---

### 6. Winner priority

The most specific matching Winner Animation is selected first.

Simplified:

```text
complete winning visit
→ winning dart
→ player-specific winner
→ generic winner
```

Inside each level:

```text
Player name
→ Player slot
→ Generic
```

Example:

```text
gameshot_playername_s25_bull
→ gameshot_player1_s25_bull
→ gameshot_s25_bull
→ gameshot_playername_bull
→ gameshot_player1_bull
→ gameshot_bull
→ gameshot_playername
→ gameshot_player1
→ gameshot
```

The same logic applies to `matchshot`.

---

### 7. Optional Board ID filtering

Board filtering is mainly intended for **online matches**.

Without filtering, throws or wins from a remote opponent on another board may trigger local animations.

Example:

```text
own 180
→ local animation should play

remote opponent scores 180
→ local animation should not play
```

To prevent this, enter your own Board ID in the Animation settings:

```text
Board IDs:
your-board-id
```

One Board ID per line:

```text
Board IDs:
board-id-1
board-id-2
```

A Board ID can for example be found in the Autodarts board URL:

```text
/boards/<board-id>
```

#### Empty field

```text
Board IDs:
[empty]
```

→ filtering disabled  
→ Animations work as before for all boards

#### Board ID configured

```text
own board ID
→ own Animations play

different board
→ Animations are blocked
```

This also applies to:

```text
gameshot
gameshot_playername
gameshot_playername_d20
matchshot
matchshot_player2
matchshot_player2_s25_bull
```

This prevents a remote opponent from triggering local celebration GIFs or personalized Winner Animations.

To disable filtering again, simply remove all Board IDs.

---

### 8. Compatibility

Existing generic Animation triggers continue to work unchanged:

```text
180
100-140
s20
d20
t20
bull
outside
busted
t20_t20_t20
gameshot
```

The new Player, Matchshot, Winning Dart and Winning Visit variants are additional options.

Existing random selection between multiple Animations using the same selected trigger is preserved.

---

### Tests

Successfully tested among others:

```text
Player name → slot → generic fallback
stable player1/player2 mapping across alternating leg starters

180 / bull / outside / busted
ranges
dart combinations

gameshot_playername
matchshot_playername

gameshot_playername_d10
gameshot_player1_d10
gameshot_d10

gameshot_playername_s25_bull
gameshot_player1_s25_bull
gameshot_s25_bull

matchshot_playername_d1
matchshot_playername_s25_bull

Matchshot → Gameshot fallback
```

Board filtering was also live-tested:

```text
Board IDs empty
→ Animations play

own Board ID
→ normal Animation plays
→ Gameshot plays
→ Matchshot plays

different/invalid Board ID
→ normal Animation blocked
→ Gameshot blocked
→ Matchshot blocked
```

`yarn build` succeeds.

`yarn compile` still reports only the same 17 pre-existing errors in 10 files already present in 3.0.7. This PR introduces no new TypeScript errors.

### Possible follow-up

The new trigger-resolution logic could later also be reused for Sound FX so Animations and sounds can share the same player-, checkout- and finish-specific syntax.

This is intentionally not part of this PR.

Closes #224  
Closes #169  
Addresses #108